### PR TITLE
Make a number of adjustments to the integration setup

### DIFF
--- a/custom_components/abbfreeathome-ci/__init__.py
+++ b/custom_components/abbfreeathome-ci/__init__.py
@@ -41,6 +41,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    # Close websocket connection
+    free_at_home: FreeAtHome = hass.data[DOMAIN][entry.entry_id]
+
+    # TODO: Implement this in the FreeAtHome class in the PyPi package.
+    await free_at_home._api.ws_close()  # noqa: SLF001
+
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/custom_components/abbfreeathome-ci/manifest.json
+++ b/custom_components/abbfreeathome-ci/manifest.json
@@ -10,10 +10,10 @@
     "homekit": {},
     "iot_class": "local_push",
     "requirements": [
-        "local-abbfreeathome==1.0.0"
+        "local-abbfreeathome==1.1.0"
     ],
     "ssdp": [],
-    "version": "0.2.0",
+    "version": "0.3.0",
     "zeroconf": [
         {
             "type": "_http._tcp.local.",

--- a/custom_components/abbfreeathome-ci/strings.json
+++ b/custom_components/abbfreeathome-ci/strings.json
@@ -1,21 +1,32 @@
 {
     "config": {
-        "step": {
-            "user": {
-                "data": {
-                    "host": "[%key:common::config_flow::data::host%]",
-                    "username": "[%key:common::config_flow::data::username%]",
-                    "password": "[%key:common::config_flow::data::password%]"
-                }
-            }
+      "step": {
+        "user": {
+          "title": "Free@Home",
+          "data": {
+            "host": "[%key:common::config_flow::data::host%]",
+            "username": "[%key:common::config_flow::data::username%]",
+            "password": "[%key:common::config_flow::data::password%]"
+          }
         },
-        "error": {
-            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-            "unknown": "[%key:common::config_flow::error::unknown%]"
-        },
-        "abort": {
-            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+        "zeroconf_confirm": {
+          "title": "Free@Home",
+          "description": "Do you want to setup {name}?",
+          "data": {
+            "host": "[%key:common::config_flow::data::host%]",
+            "username": "[%key:common::config_flow::data::username%]",
+            "password": "[%key:common::config_flow::data::password%]"
+          }
         }
+      },
+      "error": {
+        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+        "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+        "unknown": "[%key:common::config_flow::error::unknown%]"
+      },
+      "abort": {
+        "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      }
     }
-}
+  }
+  

--- a/custom_components/abbfreeathome-ci/translations/en.json
+++ b/custom_components/abbfreeathome-ci/translations/en.json
@@ -14,7 +14,17 @@
                     "host": "Host",
                     "password": "Password",
                     "username": "Username"
-                }
+                },
+                "title": "Free@Home"
+            },
+            "zeroconf_confirm": {
+                "data": {
+                    "host": "Host",
+                    "password": "Password",
+                    "username": "Username"
+                },
+                "description": "Do you want to setup {name} ({host})?",
+                "title": "Free@Home"
             }
         }
     }


### PR DESCRIPTION
This PR makes a number of enhancements to the setup flow.

- The zeroconf and user setup won't follow the exact same flow. Making the code easier to manage.
- Use the SysAP serial number to set the unique id on both zeroconf and user flows. This should ensure that zerconf doesn't recognize the device as a new device even if the SysAP name is changed. This also ensures the user can't setup the integration twice for the same SysAP.
- When deleting the integration, ensure the websocket gets closed.