### PR TITLE
Set description placeholders more globally

### DIFF
--- a/custom_components/abbfreeathome-ci/config_flow.py
+++ b/custom_components/abbfreeathome-ci/config_flow.py
@@ -150,7 +150,6 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self._async_show_setup_form(
             step_id="zeroconf_confirm",
-            description_placeholders={CONF_NAME: self._title, CONF_HOST: self._host},
         )
 
     async def async_step_zeroconf_confirm(
@@ -178,12 +177,16 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
 
     @callback
     def _async_show_setup_form(
-        self,
-        step_id: str,
-        errors: dict[str, str] | None = None,
-        description_placeholders: Mapping[str, str | None] | None = None,
+        self, step_id: str, errors: dict[str, str] | None = None
     ) -> ConfigFlowResult:
         """Show the setup form to the user."""
+        description_placeholders: Mapping[str, str | None] = {}
+
+        if self._title:
+            description_placeholders[CONF_NAME] = self._title
+        if self._host:
+            description_placeholders[CONF_HOST] = self._host
+
         return self.async_show_form(
             step_id=step_id,
             data_schema=_schema_with_defaults(step_id=step_id),

--- a/custom_components/abbfreeathome-ci/manifest.json
+++ b/custom_components/abbfreeathome-ci/manifest.json
@@ -13,7 +13,7 @@
         "local-abbfreeathome==1.1.0"
     ],
     "ssdp": [],
-    "version": "0.3.0",
+    "version": "0.3.1",
     "zeroconf": [
         {
             "type": "_http._tcp.local.",


### PR DESCRIPTION
![Screenshot 2024-10-03 at 15 33 58](https://github.com/user-attachments/assets/7baeafeb-d509-4776-a949-b5eeaaab92cc)

The description placeholder were not getting set everywhere. Adjust this to set it more globally.