### PR TITLE
Add SysAP as a new device, link switches to it

### DIFF
--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
-from abbfreeathome.api import FreeAtHomeApi
+from abbfreeathome.api import FreeAtHomeApi, FreeAtHomeSettings
 from abbfreeathome.freeathome import FreeAtHome
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
-from .const import DOMAIN
+from .const import CONF_SERIAL, DOMAIN
 
 PLATFORMS: list[Platform] = [Platform.SWITCH]
 
@@ -17,6 +18,11 @@ PLATFORMS: list[Platform] = [Platform.SWITCH]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up ABB free@home from a config entry."""
 
+    # Get settings from Free@Home SysAP
+    _free_at_home_settings = FreeAtHomeSettings(host=entry.data[CONF_HOST])
+    await _free_at_home_settings.load()
+
+    # Create the FreeAtHome Object
     _free_at_home = FreeAtHome(
         api=FreeAtHomeApi(
             host=entry.data[CONF_HOST],
@@ -31,9 +37,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Load devices into the free at home object
     await _free_at_home.load_devices()
 
+    # Register SysAP as a Device
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.data[CONF_SERIAL])},
+        manufacturer="ABB Busch-Jaeger",
+        model="System Access Point",
+        name=_free_at_home_settings.name,
+        serial_number=entry.data[CONF_SERIAL],
+        sw_version=_free_at_home_settings.version,
+        hw_version=_free_at_home_settings.hardware_version,
+        configuration_url=entry.data[CONF_HOST],
+    )
+
+    # Add the FreeAtHome object to hass data
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _free_at_home
+
+    # Setup platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Create a websocket connection for listen for changes in device entities.
     entry.async_create_background_task(hass, _free_at_home.ws_listen(), f"{DOMAIN}_ws")
 
     return True


### PR DESCRIPTION
This addresses #8 

This adds the SysAP as a new device and links all switches to it. You'll see this as a new device in the list of devices for the integration.

Right now it won't have any controls, the ABB local api doesn't provide much functionality for controlling the SysAP (that I can tell). But if we find anything we can add it.

It will list information about the SysAP including:

- Firmware Version
- Hardware Version
- Serial Number

It will also allow you to "Visit" the SysAP configuration page with a link to the configuration URL.

<img width="338" alt="Screenshot 2024-10-11 at 11 30 54" src="https://github.com/user-attachments/assets/e8062052-ac66-4627-a63a-068a45c37b17">
