### PR TITLE
Adds new device dump service

### DIFF
--- a/custom_components/abbfreeathome_ci/const.py
+++ b/custom_components/abbfreeathome_ci/const.py
@@ -4,3 +4,6 @@ DOMAIN = "abbfreeathome_ci"
 
 # Domain Configuration
 CONF_SERIAL = "serial"
+
+# Service Calls
+DEVICE_DUMP = "device_dump"

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "requirements": ["local-abbfreeathome==1.3.0"],
   "ssdp": [],
-  "version": "0.5.0",
+  "version": "0.5.1",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/custom_components/abbfreeathome_ci/services.yaml
+++ b/custom_components/abbfreeathome_ci/services.yaml
@@ -1,2 +1,1 @@
 device_dump:
-  description: "Dump the list of devices to service response."

--- a/custom_components/abbfreeathome_ci/services.yaml
+++ b/custom_components/abbfreeathome_ci/services.yaml
@@ -1,0 +1,2 @@
+device_dump:
+  description: "Dump the list of devices to service response."

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -28,5 +28,11 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "services": {
+    "device_dump": {
+      "name": "Device Dump",
+      "description": "Dump the list of devices to service response."
+    }
   }
 }

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -28,5 +28,11 @@
                 "title": "Free@Home - Confirm"
             }
         }
+    },
+    "services": {
+      "device_dump": {
+        "name": "Device Dump",
+        "description": "Dump the list of devices to service response."
+      }
     }
 }


### PR DESCRIPTION
This adds a new "action" to Home Assistant that'll allow a user to view the list of devices in their setup.

<img width="1460" alt="image" src="https://github.com/user-attachments/assets/d5ced633-0ad5-4529-a6d4-a61015f59e1f">

Bump version to patch since this is added to help debug an issue.