### PR TITLE
Add WIRELESS_RF as allowed interface

### DIFF
--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -37,7 +37,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             username=entry.data[CONF_USERNAME],
             password=entry.data[CONF_PASSWORD],
         ),
-        interfaces=[Interface.UNDEFINED, Interface.WIRED_BUS, Interface.VIRTUAL_DEVICE],
+        interfaces=[
+            Interface.UNDEFINED,
+            Interface.WIRED_BUS,
+            Interface.WIRELESS_RF,
+            Interface.VIRTUAL_DEVICE,
+        ],
     )
 
     # Verify we can fetch the config from the api
@@ -70,8 +75,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_create_background_task(hass, _free_at_home.ws_listen(), f"{DOMAIN}_ws")
 
     # Setup services
-    if not hass.services.has_service(DOMAIN, DEVICE_DUMP):
-        await async_setup_service(hass, entry)
+    await async_setup_service(hass, entry)
 
     return True
 

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -7,9 +7,9 @@
   "documentation": "https://github.com/kingsleyadam/local-abbfreeathome-hass",
   "homekit": {},
   "iot_class": "local_push",
-  "requirements": ["local-abbfreeathome==1.3.0"],
+  "requirements": ["local-abbfreeathome==1.3.1"],
   "ssdp": [],
-  "version": "0.5.1",
+  "version": "0.5.2",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",


### PR DESCRIPTION
This adds the `WIRELESS_RF` interface for missing wireless devices.

Remove unnecessary if statement from previous patch version.

Bump version