### PR TITLE
Bump PyPi package to 1.3.2

### DIFF
--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -7,9 +7,9 @@
   "documentation": "https://github.com/kingsleyadam/local-abbfreeathome-hass",
   "homekit": {},
   "iot_class": "local_push",
-  "requirements": ["local-abbfreeathome==1.3.1"],
+  "requirements": ["local-abbfreeathome==1.3.2"],
   "ssdp": [],
-  "version": "0.5.2",
+  "version": "0.5.3",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",


### PR DESCRIPTION
Bumps PyPi package to 1.3.2 to include https://github.com/kingsleyadam/local-abbfreeathome/pull/30