### PR TITLE
Implement diagnostics settings for integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,32 @@ When adding the integration manually you'll be prompted for the `Hostname`, `Use
 ### Automatic Area Discovery
 
 When adding the integration it'll automatically add devices to different `Areas` in Home Assistant. The areas will be pulled from your ABB Free@Home Configuration/Floorplan. When prompted to add the devices double check the area for each.
+
+## Debugging
+
+If you're having issues with the integration, maybe not all devices are showing up, or entities are not responding as you'd expect, you can do two things to help debug.
+
+### Enable Verbose Logging
+
+You can enable more verbose logging within your Home Assistant installation just for this integration by adding the following to your Home Assistant `configuration.yaml` file.
+
+By default the Home Assistant default logger is `warning`, this configuration won't change that. But it'll create additional logs for both this integration and the PyPi module running a number of calls to the SysAP.
+
+
+```yaml
+logger:
+  default: warning
+  logs:
+    abbfreeathome: debug
+    custom_components.abbfreeathome_ci: debug
+```
+
+### Download Diagnostics
+
+If you request help via GitHub [Discussions](https://github.com/kingsleyadam/local-abbfreeathome-hass/discussions) you will likely be asked to share the integration diagnostics.
+
+The [diagnostics](https://www.home-assistant.io/docs/configuration/troubleshooting/#download-diagnostics) will share some information about your Home Assistant installation and this integration's installation.
+
+To pull the diagnostics about this integration navigate to the integration under `Settings` --> `Devices & Services` --> `Busch Jaeger/ABB Free@Home (Local API)`. Click the 3 dots next to the integration entity and click `Download Diagnostics`. Private information should be redacted from the download, but it's always good to double check the output before sending.
+
+Along with the `home_assistant` and `integration_manifest` you should also see `data` which includes your SysAP configuration and devices.

--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -2,23 +2,16 @@
 
 from __future__ import annotations
 
-import json
-
 from abbfreeathome.api import FreeAtHomeApi, FreeAtHomeSettings
 from abbfreeathome.bin.interface import Interface
 from abbfreeathome.freeathome import FreeAtHome
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import (
-    HomeAssistant,
-    ServiceCall,
-    ServiceResponse,
-    SupportsResponse,
-)
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from .const import CONF_SERIAL, DEVICE_DUMP, DOMAIN
+from .const import CONF_SERIAL, DOMAIN
 
 PLATFORMS: list[Platform] = [Platform.SWITCH]
 
@@ -74,9 +67,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Create a websocket connection for listen for changes in device entities.
     entry.async_create_background_task(hass, _free_at_home.ws_listen(), f"{DOMAIN}_ws")
 
-    # Setup services
-    await async_setup_service(hass, entry)
-
     return True
 
 
@@ -91,21 +81,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-async def async_setup_service(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Set up services for Free@Home integration."""
-
-    async def device_dump(call: ServiceCall) -> ServiceResponse:
-        """Service call to dump all devices into json file."""
-
-        # Fetch the list of devices
-        _fah = hass.data[DOMAIN][entry.entry_id]
-        _devices = (await _fah.get_config()).get("devices")
-
-        # Return the device list in JSON format.
-        return {"devices": json.dumps(_devices, indent=2)}
-
-    hass.services.async_register(
-        DOMAIN, DEVICE_DUMP, device_dump, supports_response=SupportsResponse.ONLY
-    )

--- a/custom_components/abbfreeathome_ci/const.py
+++ b/custom_components/abbfreeathome_ci/const.py
@@ -4,6 +4,3 @@ DOMAIN = "abbfreeathome_ci"
 
 # Domain Configuration
 CONF_SERIAL = "serial"
-
-# Service Calls
-DEVICE_DUMP = "device_dump"

--- a/custom_components/abbfreeathome_ci/diagnostics.py
+++ b/custom_components/abbfreeathome_ci/diagnostics.py
@@ -1,0 +1,24 @@
+"""Diagnostics support for ABB Free@Home."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from abbfreeathome.freeathome import FreeAtHome
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+TO_REDACT = {"latitude", "longitude", "sysapName", "uartSerialNumber"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    _free_at_home: FreeAtHome = hass.data[DOMAIN][entry.entry_id]
+
+    return async_redact_data(await _free_at_home.get_config(), TO_REDACT)

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "requirements": ["local-abbfreeathome==1.3.2"],
   "ssdp": [],
-  "version": "0.5.3",
+  "version": "0.5.4",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/custom_components/abbfreeathome_ci/services.yaml
+++ b/custom_components/abbfreeathome_ci/services.yaml
@@ -1,1 +1,0 @@
-device_dump:

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -28,11 +28,5 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
-  },
-  "services": {
-    "device_dump": {
-      "name": "Device Dump",
-      "description": "Dump the list of devices to service response."
-    }
   }
 }

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -28,11 +28,5 @@
                 "title": "Free@Home - Confirm"
             }
         }
-    },
-    "services": {
-      "device_dump": {
-        "name": "Device Dump",
-        "description": "Dump the list of devices to service response."
-      }
     }
 }


### PR DESCRIPTION
This address #21 , instead of using a service call to get the device info, this tags up the diagnostic download for the implementation.

When downloading the diagnostics for the integration it'll include the entire Free@Home configuration in addition to information about the integration (manifest) and HA instance.

I've redacted the longitude and latitude to protect the users location, as well as the sysAP Name and `uartSerialNumber`. Some people (myself included) may use indetifiable information in the SysAP name.

I've also removed the dump service completely.