### PR TITLE
Adds support for sensor and binary sensor platforms

### DIFF
--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import device_registry as dr
 
 from .const import CONF_SERIAL, DOMAIN
 
-PLATFORMS: list[Platform] = [Platform.SWITCH]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/abbfreeathome_ci/binary_sensor.py
+++ b/custom_components/abbfreeathome_ci/binary_sensor.py
@@ -1,0 +1,126 @@
+"""Create ABB Free@Home binary sensor entities."""
+
+from abbfreeathome.devices.movement_detector import MovementDetector
+from abbfreeathome.devices.switch_sensor import SwitchSensor
+from abbfreeathome.freeathome import FreeAtHome
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_SERIAL, DOMAIN
+
+
+class FreeAtHomeBinarySensorDescription:
+    """Class describing FreeAtHome sensor entities."""
+
+    def __init__(
+        self,
+        device_class: MovementDetector | SwitchSensor,
+        value_attribute: str,
+        entity_description: BinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the FreeAtHomeSensorDescription class."""
+        self.device_class: MovementDetector | SwitchSensor = device_class
+        self.value_attribute: str = value_attribute
+        self.entity_description = entity_description
+
+
+SENSOR_TYPES: tuple[FreeAtHomeBinarySensorDescription, ...] = (
+    FreeAtHomeBinarySensorDescription(
+        device_class=MovementDetector,
+        value_attribute="state",
+        entity_description=BinarySensorEntityDescription(
+            key="MovementDetectorMotion",
+            device_class=BinarySensorDeviceClass.MOTION,
+            translation_key="movement_detector_motion",
+        ),
+    ),
+    FreeAtHomeBinarySensorDescription(
+        device_class=SwitchSensor,
+        value_attribute="state",
+        entity_description=BinarySensorEntityDescription(
+            key="SwitchSensorOnOff",
+            translation_key="switch_sensor",
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up binary sensor entities."""
+    free_at_home: FreeAtHome = hass.data[DOMAIN][entry.entry_id]
+
+    for description in SENSOR_TYPES:
+        async_add_entities(
+            FreeAtHomeBinarySensorEntity(
+                device,
+                value_attribute=description.value_attribute,
+                entity_description=description.entity_description,
+                sysap_serial_number=entry.data[CONF_SERIAL],
+            )
+            for device in free_at_home.get_device_by_class(
+                device_class=description.device_class
+            )
+        )
+
+
+class FreeAtHomeBinarySensorEntity(BinarySensorEntity):
+    """Defines a Free@Home binary sensor entity."""
+
+    _attr_should_poll: bool = False
+    _attr_has_entity_name: bool = True
+
+    def __init__(
+        self,
+        device: MovementDetector | SwitchSensor,
+        value_attribute: str,
+        entity_description: BinarySensorEntityDescription,
+        sysap_serial_number: str,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__()
+        self._device = device
+        self._value_attribute = value_attribute
+        self._sysap_serial_number = sysap_serial_number
+
+        self.entity_description = entity_description
+        self._attr_unique_id = (
+            f"{device.device_id}_{device.channel_id}_{entity_description.key}"
+        )
+        self._attr_translation_placeholders = {"channel_name": device.channel_name}
+
+    async def async_added_to_hass(self) -> None:
+        """Run when this Entity has been added to HA."""
+        self._device.register_callback(self.async_write_ha_state)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Entity being removed from hass."""
+        self._device.remove_callback(self.async_write_ha_state)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Information about this entity/device."""
+        return {
+            "identifiers": {(DOMAIN, self._device.device_id)},
+            "name": self._device.device_name,
+            "manufacturer": "ABB busch-jaeger",
+            "serial_number": self._device.device_id,
+            "suggested_area": self._device.room_name,
+            "via_device": (DOMAIN, self._sysap_serial_number),
+        }
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return state of the binary sensor."""
+        return getattr(self._device, self._value_attribute)

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -7,9 +7,9 @@
   "documentation": "https://github.com/kingsleyadam/local-abbfreeathome-hass",
   "homekit": {},
   "iot_class": "local_push",
-  "requirements": ["local-abbfreeathome==1.3.2"],
+  "requirements": ["local-abbfreeathome==1.5.0"],
   "ssdp": [],
-  "version": "0.5.4",
+  "version": "0.6.0",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/custom_components/abbfreeathome_ci/sensor.py
+++ b/custom_components/abbfreeathome_ci/sensor.py
@@ -1,0 +1,121 @@
+"""Create ABB Free@Home sensor entities."""
+
+from abbfreeathome.devices.movement_detector import MovementDetector
+from abbfreeathome.freeathome import FreeAtHome
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import LIGHT_LUX
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_SERIAL, DOMAIN
+
+
+class FreeAtHomeSensorDescription:
+    """Class describing FreeAtHome sensor entities."""
+
+    def __init__(
+        self,
+        device_class: MovementDetector,
+        value_attribute: str,
+        entity_description: SensorEntityDescription,
+    ) -> None:
+        """Initialize the FreeAtHomeSensorDescription class."""
+        self.device_class: MovementDetector = device_class
+        self.value_attribute: str = value_attribute
+        self.entity_description = entity_description
+
+
+SENSOR_TYPES: tuple[FreeAtHomeSensorDescription, ...] = (
+    FreeAtHomeSensorDescription(
+        device_class=MovementDetector,
+        value_attribute="brightness",
+        entity_description=SensorEntityDescription(
+            key="MovementDetectorBrightness",
+            device_class=SensorDeviceClass.ILLUMINANCE,
+            native_unit_of_measurement=LIGHT_LUX,
+            state_class=SensorStateClass.MEASUREMENT,
+            translation_key="movement_detector_brightness",
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up sensors."""
+    free_at_home: FreeAtHome = hass.data[DOMAIN][entry.entry_id]
+
+    for description in SENSOR_TYPES:
+        async_add_entities(
+            FreeAtHomeSensorEntity(
+                device,
+                value_attribute=description.value_attribute,
+                entity_description=description.entity_description,
+                sysap_serial_number=entry.data[CONF_SERIAL],
+            )
+            for device in free_at_home.get_device_by_class(
+                device_class=description.device_class
+            )
+        )
+
+
+class FreeAtHomeSensorEntity(SensorEntity):
+    """Defines a Free@Home sensor entity."""
+
+    _attr_should_poll: bool = False
+    _attr_has_entity_name: bool = True
+
+    def __init__(
+        self,
+        device: MovementDetector,
+        value_attribute: str,
+        entity_description: SensorEntityDescription,
+        sysap_serial_number: str,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__()
+        self._device = device
+        self._value_attribute = value_attribute
+        self._sysap_serial_number = sysap_serial_number
+
+        self.entity_description = entity_description
+        self._attr_unique_id = (
+            f"{device.device_id}_{device.channel_id}_{entity_description.key}"
+        )
+        self._attr_translation_placeholders = {"channel_name": device.channel_name}
+
+    async def async_added_to_hass(self) -> None:
+        """Run when this Entity has been added to HA."""
+        self._device.register_callback(self.async_write_ha_state)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Entity being removed from hass."""
+        self._device.remove_callback(self.async_write_ha_state)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Information about this entity/device."""
+        return {
+            "identifiers": {(DOMAIN, self._device.device_id)},
+            "name": self._device.device_name,
+            "manufacturer": "ABB busch-jaeger",
+            "serial_number": self._device.device_id,
+            "suggested_area": self._device.room_name,
+            "via_device": (DOMAIN, self._sysap_serial_number),
+        }
+
+    @property
+    def native_value(self) -> float | None:
+        """Return state of the sensor."""
+        return getattr(self._device, self._value_attribute)

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -28,5 +28,20 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "movement_detector_motion": {
+        "name": "Motion"
+      },
+      "switch_sensor": {
+        "name": "Switch Sensor"
+      }
+    },
+    "sensor": {
+      "movement_detector_brightness": {
+        "name": "Illuminance"
+      }
+    }
   }
 }

--- a/custom_components/abbfreeathome_ci/switch.py
+++ b/custom_components/abbfreeathome_ci/switch.py
@@ -56,7 +56,6 @@ class FreeAtHomeSwitchEntity(SwitchEntity):
             "identifiers": {(DOMAIN, self._switch.device_id)},
             "name": self._switch.device_name,
             "manufacturer": "ABB busch-jaeger",
-            "model": "SwitchingActuator",
             "serial_number": self._switch.device_id,
             "suggested_area": self._switch.room_name,
             "via_device": (DOMAIN, self._sysap_serial_number),

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -28,5 +28,20 @@
                 "title": "Free@Home - Confirm"
             }
         }
+    },
+    "entity": {
+        "binary_sensor": {
+            "movement_detector_motion": {
+                "name": "Motion"
+            },
+            "switch_sensor": {
+                "name": "Switch Sensor"
+            }
+        },
+        "sensor": {
+            "movement_detector_brightness": {
+                "name": "Illuminance"
+            }
+        }
     }
 }


### PR DESCRIPTION
This addresses #24 , This adds support for both sensor and binary sensor platforms in Home Assistant.

The initial implementation supports

- Motion Detector - Both Motion (Binary Sensor) and Illuminance (Sensor)
- Switch Sensor (Binary Sensor)

A note and something that may be confusing, the switch sensor only follows the state of the switch on physical button presses. It doesn't follow the state of the light it may be controlling. If you turn off a light with Home Assistant, the Switch Sensor won't be updated to reflect the light state. Because of this we should probably also implement an Event when the Switch is physically pressed, the event will trigger regardless of if the state is already On/Off.

This also includes a translations update to ensure we can translate the name of the sensors in the future.