### PR TITLE
Only add a new sensor if it has a value other than None

### DIFF
--- a/custom_components/abbfreeathome_ci/binary_sensor.py
+++ b/custom_components/abbfreeathome_ci/binary_sensor.py
@@ -72,6 +72,7 @@ async def async_setup_entry(
             for device in free_at_home.get_device_by_class(
                 device_class=description.device_class
             )
+            if getattr(device, description.value_attribute) is not None
         )
 
 

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -7,9 +7,9 @@
   "documentation": "https://github.com/kingsleyadam/local-abbfreeathome-hass",
   "homekit": {},
   "iot_class": "local_push",
-  "requirements": ["local-abbfreeathome==1.5.0"],
+  "requirements": ["local-abbfreeathome==1.7.0"],
   "ssdp": [],
-  "version": "0.7.0",
+  "version": "0.7.1",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/custom_components/abbfreeathome_ci/sensor.py
+++ b/custom_components/abbfreeathome_ci/sensor.py
@@ -67,6 +67,7 @@ async def async_setup_entry(
             for device in free_at_home.get_device_by_class(
                 device_class=description.device_class
             )
+            if getattr(device, description.value_attribute) is not None
         )
 
 


### PR DESCRIPTION
This addresses #27 , only add a sensor if there's a value. Some devices may not have all the same sensors, so we should only add a new sensor if it has a value other than None.

New version of the PyPi package ensures all sensors have an initial value of None to avoid any attribute exceptions.