### PR TITLE
Add reconfigure integration flow.

### DIFF
--- a/custom_components/abbfreeathome_ci/config_flow.py
+++ b/custom_components/abbfreeathome_ci/config_flow.py
@@ -30,7 +30,9 @@ from .const import CONF_SERIAL, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-def _schema_with_defaults(host: str | None = None, step_id: str = "user") -> vol.Schema:
+def _schema_with_defaults(
+    host: str | None = None, username: str | None = None, step_id: str = "user"
+) -> vol.Schema:
     schema = vol.Schema({})
 
     if step_id == "user":
@@ -38,7 +40,7 @@ def _schema_with_defaults(host: str | None = None, step_id: str = "user") -> vol
 
     return schema.extend(
         {
-            vol.Required(CONF_USERNAME, default="installer"): str,
+            vol.Required(CONF_USERNAME, default=username or "installer"): str,
             vol.Required(CONF_PASSWORD): str,
         }
     )
@@ -171,9 +173,43 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self._async_create_entry()
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle user initiated reconfigure flow."""
+        entry = self._get_reconfigure_entry()
+
+        self._host = entry.data[CONF_HOST]
+        self._name = entry.data[CONF_NAME]
+        self._username = entry.data[CONF_USERNAME]
+        self._serial_number = entry.data[CONF_SERIAL]
+
+        if user_input is None:
+            return self._async_show_setup_form(
+                step_id="reconfigure", username=self._username
+            )
+
+        errors = await validate_api(
+            host=self._host,
+            username=user_input[CONF_USERNAME],
+            password=user_input[CONF_PASSWORD],
+        )
+
+        if errors:
+            return self._async_show_setup_form(step_id="reconfigure", errors=errors)
+
+        self._username = user_input[CONF_USERNAME]
+        self._password = user_input[CONF_PASSWORD]
+
+        return self._async_update_reload_and_abort()
+
     @callback
     def _async_show_setup_form(
-        self, step_id: str, errors: dict[str, str] | None = None
+        self,
+        step_id: str,
+        errors: dict[str, str] | None = None,
+        host: str | None = None,
+        username: str | None = None,
     ) -> ConfigFlowResult:
         """Show the setup form to the user."""
         description_placeholders: Mapping[str, str | None] = {}
@@ -187,7 +223,9 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id=step_id,
-            data_schema=_schema_with_defaults(step_id=step_id),
+            data_schema=_schema_with_defaults(
+                step_id=step_id, host=host, username=username
+            ),
             errors=errors or {},
             description_placeholders=description_placeholders,
         )
@@ -200,6 +238,16 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_SERIAL: self._serial_number,
                 CONF_NAME: self._name,
                 CONF_HOST: self._host,
+                CONF_USERNAME: self._username,
+                CONF_PASSWORD: self._password,
+            },
+        )
+
+    @callback
+    def _async_update_reload_and_abort(self) -> ConfigFlowResult:
+        return self.async_update_reload_and_abort(
+            self._get_reconfigure_entry(),
+            data_updates={
                 CONF_USERNAME: self._username,
                 CONF_PASSWORD: self._password,
             },

--- a/custom_components/abbfreeathome_ci/config_flow.py
+++ b/custom_components/abbfreeathome_ci/config_flow.py
@@ -177,7 +177,10 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle user initiated reconfigure flow."""
-        entry = self._get_reconfigure_entry()
+        try:
+            entry = self._get_reconfigure_entry()
+        except AttributeError:
+            return self.async_abort(reason="reconfigure_not_supported")
 
         self._host = entry.data[CONF_HOST]
         self._name = entry.data[CONF_NAME]

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -36,7 +36,8 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "reconfigure_not_supported": "Reconfigure for this integration is only supported on Home Assistant version 2024.11.0 or newer."
     }
   },
   "entity": {

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -18,6 +18,14 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
+      },
+      "reconfigure": {
+        "title": "Free@Home - Reconfigure",
+        "description": "Do you want reconfigure {name} ({serial}) at {host}?",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
       }
     },
     "error": {
@@ -26,7 +34,9 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
   "entity": {

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -3,6 +3,7 @@
         "abort": {
             "already_configured": "Device is already configured",
             "reauth_successful": "Re-authentication was successful",
+            "reconfigure_not_supported": "Reconfigure for this integration is only supported on Home Assistant version 2024.11.0 or newer.",
             "reconfigure_successful": "Re-configuration was successful"
         },
         "error": {

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -1,7 +1,9 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "reauth_successful": "Re-authentication was successful",
+            "reconfigure_successful": "Re-configuration was successful"
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -9,6 +11,14 @@
             "unknown": "Unexpected error"
         },
         "step": {
+            "reconfigure": {
+                "data": {
+                    "password": "Password",
+                    "username": "Username"
+                },
+                "description": "Do you want reconfigure {name} ({serial}) at {host}?",
+                "title": "Free@Home - Reconfigure"
+            },
             "user": {
                 "data": {
                     "host": "Host",


### PR DESCRIPTION
Add in support for integration reconfiguration.

This will use new methods only available in 2024.11.0, so this won't work initially once released. But we're targeting this integration as a core HA integration and want to keep up-to-date on it's current methods.

![Screenshot 2024-10-22 at 11 50 04](https://github.com/user-attachments/assets/0622cdcd-02c8-499c-bf9c-d182fb20c074)
