### PR TITLE
Add options to include/exclude orphan nodes

### DIFF
--- a/custom_components/abbfreeathome_ci/const.py
+++ b/custom_components/abbfreeathome_ci/const.py
@@ -1,6 +1,7 @@
 """Constants for the ABB free@home integration."""
 
-DOMAIN = "abbfreeathome_ci"
+DOMAIN = "abbfreeathome"
 
 # Domain Configuration
 CONF_SERIAL = "serial"
+CONF_INCLUDE_ORPHAN_CHANNELS = "include_orphan_channels"

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -7,9 +7,9 @@
   "documentation": "https://github.com/kingsleyadam/local-abbfreeathome-hass",
   "homekit": {},
   "iot_class": "local_push",
-  "requirements": ["local-abbfreeathome==1.7.0"],
+  "requirements": ["local-abbfreeathome==1.8.1"],
   "ssdp": [],
-  "version": "0.7.2",
+  "version": "0.8.0",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -7,7 +7,8 @@
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "include_orphan_channels": "Include channels NOT on the Free@Home floorplan?"
         }
       },
       "zeroconf_confirm": {
@@ -16,7 +17,8 @@
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "include_orphan_channels": "Include channels NOT on the Free@Home floorplan?"
         }
       },
       "reconfigure": {
@@ -24,7 +26,8 @@
         "description": "Do you want reconfigure {name} ({serial}) at {host}?",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "include_orphan_channels": "Include channels NOT on the Free@Home floorplan?"
         }
       }
     },

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -14,6 +14,7 @@
         "step": {
             "reconfigure": {
                 "data": {
+                    "include_orphan_channels": "Include channels NOT on the Free@Home floorplan?",
                     "password": "Password",
                     "username": "Username"
                 },
@@ -23,6 +24,7 @@
             "user": {
                 "data": {
                     "host": "Host",
+                    "include_orphan_channels": "Include channels NOT on the Free@Home floorplan?",
                     "password": "Password",
                     "username": "Username"
                 },
@@ -32,6 +34,7 @@
             "zeroconf_confirm": {
                 "data": {
                     "host": "Host",
+                    "include_orphan_channels": "Include channels NOT on the Free@Home floorplan?",
                     "password": "Password",
                     "username": "Username"
                 },


### PR DESCRIPTION
This grants the ability to exclude orphan channels from the Free@Home configuration.

The default in new integration setup will be false (exclude orphan channels). But because I don't want to change existing behavior, when this migrates the configs to a newer version it'll keep the current value of True.

Right now, to change this you must first delete the integration and re-add.

In the next release of Home Assistant this integration will be able to be "reconfigured" and this value can be changed.