### PR TITLE
Add function, pairing to diagnostics, update readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,25 @@ Because of this, the integration will adhere to the strict [styling and code gui
 
 ## Device Support
 
-This is a new repo written from the ground up in tandem with the PyPi Package [local-abbfreeathome](https://pypi.org/project/local-abbfreeathome/#description) in order to communicate with the ABB Free@Home System over the **local** api. **The initial list of supported devices is 1 (Switch/Actuator).**
+The current list of supported devices by function are:
 
-The initial goal is to thoroughly test the integration (and by proxy the PyPi package) to ensure there are no bugs within the code. It's also to ensure it's feature and code complete (e.g. ZeroConf, UnitTests).
+| Function | Platform(s)
+|--|--|
+| FID_SWITCH_ACTUATOR | `Switch` |
+| FID_SWITCH_SENSOR | `Binary Sensor`, `Event` |
+| FID_MOVEMENT_DETECTOR | `Binary Sensor`, `Sensor` |
+| FID_DIMMING_ACTUATOR | `Light` |
+| FID_WINDOW_DOOR_SENSOR | `Binary Sensor` |
+| FID_WINDOW_DOOR_POSITION_SENSOR | `Binary Sensor`, `Sensor` |
+| FID_SMOKE_DETECTOR | `Binary Sensor` |
+| FID_CARBON_MONOXIDE_SENSOR | `Binary Sensor` |
 
-Once this is feature and code complete it should provide a solid base as to which new devices can be integrated into. I (kingsleyadam) don't have access to the number of different ABB devices and would rely on others to either provide configurations, or contribute code directly in order to add additional device support. It'll be much easier long-term if the core code is stable.
-
-> **If you need support for additional devices I'd strongly reccomend you check out the repo [here](https://github.com/jheling/freeathome). That repo has been around for a long time and provides support for a number of devices.**
 
 ### Additional Devices
 
-If you would like your device supported in this integration, please start by opening a GitHub issue with the device configuration.
+This is a new repo written from the ground up in tandem with the PyPi Package [local-abbfreeathome](https://pypi.org/project/local-abbfreeathome/#description) in order to communicate with the ABB Free@Home System over the **local** api. **The list of supported functions may not include your device.** If you expect a device to appear and don't, please open a new issues and include the device configuration. To fetch your device configuration download the integration [diagnostics](#download-diagnostics).
+
+I (kingsleyadam) don't have access to the number of different ABB devices and would rely on others to either provide configurations, or contribute code directly in order to add additional device support.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Because of this, the integration will adhere to the strict [styling and code gui
 
 The current list of supported devices by function are:
 
-| Function | Platform(s)
+| Function | Platform(s) |
 |--|--|
 | FID_SWITCH_ACTUATOR | `Switch` |
 | FID_SWITCH_SENSOR | `Binary Sensor`, `Event` |

--- a/custom_components/abbfreeathome_ci/diagnostics.py
+++ b/custom_components/abbfreeathome_ci/diagnostics.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from typing import Any
 
+from abbfreeathome.bin.function import Function
+from abbfreeathome.bin.pairing import Pairing
 from abbfreeathome.freeathome import FreeAtHome
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -15,10 +18,53 @@ from .const import DOMAIN
 TO_REDACT = {"latitude", "longitude", "sysapName", "uartSerialNumber"}
 
 
+def inject_function_pairing_names(device_list: list[dict]):
+    """Inject the function and pairing names into the list of devices."""
+    for _device_value in device_list.values():
+        for _channel_key, _channel_value in _device_value.get("channels").items():
+            try:
+                _channel_value["function"] = Function(
+                    int(_channel_value.get("functionID"), 16)
+                ).name
+            except ValueError:
+                _channel_value["function"] = "UNKNOWN"
+
+            _device_value["channels"][_channel_key] = OrderedDict(
+                sorted(_channel_value.items())
+            )
+
+            for _input_key, _input_value in _channel_value.get("inputs").items():
+                try:
+                    _input_value["pairing"] = Pairing(
+                        _input_value.get("pairingID")
+                    ).name
+                except ValueError:
+                    _input_value["pairing"] = "UNKNOWN"
+
+                _channel_value["inputs"][_input_key] = OrderedDict(
+                    sorted(_input_value.items())
+                )
+
+            for _output_key, _output_value in _channel_value.get("outputs").items():
+                try:
+                    _output_value["pairing"] = Pairing(
+                        _output_value.get("pairingID")
+                    ).name
+                except ValueError:
+                    _output_value["pairing"] = "UNKNOWN"
+
+                _channel_value["outputs"][_output_key] = OrderedDict(
+                    sorted(_output_value.items())
+                )
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     _free_at_home: FreeAtHome = hass.data[DOMAIN][entry.entry_id]
+
+    # Inject Function and Pairing names into configuration.
+    inject_function_pairing_names((await _free_at_home.get_config()).get("devices"))
 
     return async_redact_data(await _free_at_home.get_config(), TO_REDACT)

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "requirements": ["local-abbfreeathome==1.9.1"],
   "ssdp": [],
-  "version": "0.10.0",
+  "version": "0.10.1",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",


### PR DESCRIPTION
This addresses https://github.com/kingsleyadam/local-abbfreeathome-hass/issues/47

I'm adding in the pairing name and function name to the diagnostics download. I'm ensure the order of items int he dict is alphabetical so the function name is easily read with function id, etc.

I'm also updating the README to adjust text around device support with the list of supported functions by platform.

Example Output

```json
"ABB7F4FEB38E": {
  "deviceReboots": "23",
  "floor": "03",
  "room": "07",
  "interface": "TP",
  "deviceId": "9100",
  "displayName": "2nd Floor > 3rd Floor Landing Rocker",
  "unresponsive": false,
  "unresponsiveCounter": 0,
  "defect": false,
  "channels": {
    "ch0000": {
      "displayName": "2nd Floor > 3rd Floor Landing Rocker",
      "floor": "03",
      "function": "FID_SWITCH_SENSOR",
      "functionID": "0",
      "inputs": {
        "idp0000": {
          "pairing": "AL_INFO_ON_OFF",
          "pairingID": 256,
          "value": "0"
        },
        "idp0001": {
          "pairing": "AL_NIGHT",
          "pairingID": 18,
          "value": "0"
        },
        "idp0002": {
          "pairing": "AL_INFO_ERROR",
          "pairingID": 273,
          "value": "0"
        },
        "idp0004": {
          "pairing": "AL_SYSAP_INFO_ON_OFF",
          "pairingID": 261,
          "value": "0"
        },
        "idp0005": {
          "pairing": "AL_SYSAP_INFO_ERROR",
          "pairingID": 278,
          "value": "0"
        }
      },
      "outputs": {
        "odp0000": {
          "pairing": "AL_SWITCH_ON_OFF",
          "pairingID": 1,
          "value": "0"
        },
        "odp0006": {
          "pairing": "AL_SCENE_CONTROL",
          "pairingID": 4,
          "value": "0"
        }
      },
      "parameters": {
        "par0002": "50",
        "par0001": "50",
        "par0007": "1"
      },
      "room": "07"
    }
  },
  "parameters": {
    "par00ed": "1"
  }
}
```