### PR TITLE
Add DesDoorRingingSensor to event sensor

### DIFF
--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -64,7 +64,24 @@
     },
     "event": {
       "switch_sensor": {
-        "name": "Switch Event ({channel_id})"
+        "name": "Switch Event ({channel_id})",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "on": "[%key:common::state::on%]",
+              "off": "[%key:common::state::off%]"
+            }
+          }
+        }
+      },
+      "des_door_ringing_sensor": {
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "activated": "Activated"
+            }
+          }
+        }
       }
     },
     "sensor": {

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -63,8 +63,25 @@
             }
         },
         "event": {
+            "des_door_ringing_sensor": {
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "activated": "Activated"
+                        }
+                    }
+                }
+            },
             "switch_sensor": {
-                "name": "Switch Event ({channel_id})"
+                "name": "Switch Event ({channel_id})",
+                "state_attributes": {
+                    "event_type": {
+                        "state": {
+                            "off": "Off",
+                            "on": "On"
+                        }
+                    }
+                }
             }
         },
         "sensor": {


### PR DESCRIPTION
This adds the `DesDoorRingingSensor` to the event sensor. I'm implementing a lambda function as a callback to know the event type by Free@Home class.

I'm not sure how this will scale if we have any complicated state (more than just boolean). But this works pretty well for the current setup. It can always be adjusted later.

For @derjoerg to test.