### PR TITLE
Add parameter-names to Diagnostics

### DIFF
--- a/custom_components/abbfreeathome_ci/diagnostics.py
+++ b/custom_components/abbfreeathome_ci/diagnostics.py
@@ -67,7 +67,7 @@ def inject_function_pairing_parameter_names(device_list: list[dict]):
             ).items():
                 try:
                     _channel_value["parameterNames"][
-                        f"{Parameter(int(_channel_param_key.lstrip("par"), 16)).name} ({_channel_param_key}="
+                        f"{Parameter(int(_channel_param_key.lstrip("par"), 16)).name} ({_channel_param_key})"
                     ] = _channel_param_value
                 except ValueError:
                     _channel_value["parameterNames"][

--- a/custom_components/abbfreeathome_ci/diagnostics.py
+++ b/custom_components/abbfreeathome_ci/diagnostics.py
@@ -31,7 +31,7 @@ def inject_function_pairing_parameter_names(device_list: list[dict]):
                 _device_value["parameterNames"][
                     f"{Parameter(int(_device_param_key.lstrip("par"), 16)).name} ({_device_param_key})"
                 ] = _device_param_value
-            except ValueError:
+            except ValueError:  # noqa: PERF203
                 _device_value["parameterNames"][f"UNKNOWN ({_device_param_key})"] = (
                     _device_param_value
                 )
@@ -69,7 +69,7 @@ def inject_function_pairing_parameter_names(device_list: list[dict]):
                     _channel_value["parameterNames"][
                         f"{Parameter(int(_channel_param_key.lstrip("par"), 16)).name} ({_channel_param_key})"
                     ] = _channel_param_value
-                except ValueError:
+                except ValueError:  # noqa: PERF203
                     _channel_value["parameterNames"][
                         f"UNKNOWN ({_channel_param_key})"
                     ] = _channel_param_value


### PR DESCRIPTION
This adds the parameter-names to the diagnostics output.

@kingsleyadam : I need your help! The parameters on the device-level are correctly filled, but not on the channel level 😢 I don't understand the source of the problem