### PR TITLE
Implement all entities of a Weatherstation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ The current list of supported devices by function are:
 | FID_SMOKE_DETECTOR | `Binary Sensor` |
 | FID_CARBON_MONOXIDE_SENSOR | `Binary Sensor` |
 | FID_TRIGGER | `Button` |
+| FID_BRIGHTNESS_SENSOR | `Binary Sensor`, `Sensor` |
+| FID_RAIN_SENSOR | `Binary Sensor` |
+| FID_TEMPERATURE_SENSOR | `Binary Sensor`, `Sensor` |
+| FID_WIND_SENSOR | `Binary Sensor`, `Sensor` |
 
 
 ### Additional Devices

--- a/custom_components/abbfreeathome_ci/binary_sensor.py
+++ b/custom_components/abbfreeathome_ci/binary_sensor.py
@@ -2,10 +2,14 @@
 
 from typing import Any
 
+from abbfreeathome.devices.brightness_sensor import BrightnessSensor
 from abbfreeathome.devices.carbon_monoxide_sensor import CarbonMonoxideSensor
 from abbfreeathome.devices.movement_detector import MovementDetector
+from abbfreeathome.devices.rain_sensor import RainSensor
 from abbfreeathome.devices.smoke_detector import SmokeDetector
 from abbfreeathome.devices.switch_sensor import SwitchSensor
+from abbfreeathome.devices.temperature_sensor import TemperatureSensor
+from abbfreeathome.devices.wind_sensor import WindSensor
 from abbfreeathome.devices.window_door_sensor import WindowDoorSensor
 from abbfreeathome.freeathome import FreeAtHome
 
@@ -61,6 +65,38 @@ SENSOR_DESCRIPTIONS = {
             "translation_key": "window_door",
         },
     },
+    "RainSensorOnOff": {
+        "device_class": RainSensor,
+        "value_attribute": "state",
+        "entity_description_kwargs": {
+            "device_class": BinarySensorDeviceClass.MOISTURE,
+            "translation_key": "rain_sensor",
+        },
+    },
+    "BrightnessSensorOnOff": {
+        "device_class": BrightnessSensor,
+        "value_attribute": "alarm",
+        "entity_description_kwargs": {
+            "device_class": BinarySensorDeviceClass.LIGHT,
+            "translation_key": "brightness_sensor",
+        },
+    },
+    "TemperatureSensorOnOff": {
+        "device_class": TemperatureSensor,
+        "value_attribute": "alarm",
+        "entity_description_kwargs": {
+            "device_class": BinarySensorDeviceClass.COLD,
+            "translation_key": "temperature_sensor",
+        },
+    },
+    "WindSensorOnOff": {
+        "device_class": WindSensor,
+        "value_attribute": "alarm",
+        "entity_description_kwargs": {
+            "device_class": BinarySensorDeviceClass.MOVING,
+            "translation_key": "wind_sensor",
+        },
+    },
 }
 
 
@@ -96,11 +132,15 @@ class FreeAtHomeBinarySensorEntity(BinarySensorEntity):
 
     def __init__(
         self,
-        device: CarbonMonoxideSensor
+        device: BrightnessSensor
+        | CarbonMonoxideSensor
         | MovementDetector
+        | RainSensor
         | SmokeDetector
         | SwitchSensor
-        | WindowDoorSensor,
+        | TemperatureSensor
+        | WindowDoorSensor
+        | WindSensor,
         value_attribute: str,
         entity_description_kwargs: dict[str:Any],
         sysap_serial_number: str,

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://github.com/kingsleyadam/local-abbfreeathome-hass",
   "homekit": {},
   "iot_class": "local_push",
-  "requirements": ["local-abbfreeathome==1.9.2"],
+  "requirements": ["local-abbfreeathome==1.10.0"],
   "ssdp": [],
   "version": "0.11.2",
   "zeroconf": [

--- a/custom_components/abbfreeathome_ci/sensor.py
+++ b/custom_components/abbfreeathome_ci/sensor.py
@@ -2,7 +2,10 @@
 
 from typing import Any
 
+from abbfreeathome.devices.brightness_sensor import BrightnessSensor
 from abbfreeathome.devices.movement_detector import MovementDetector
+from abbfreeathome.devices.temperature_sensor import TemperatureSensor
+from abbfreeathome.devices.wind_sensor import WindSensor
 from abbfreeathome.devices.window_door_sensor import (
     WindowDoorSensor,
     WindowDoorSensorPosition,
@@ -16,7 +19,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import LIGHT_LUX
+from homeassistant.const import LIGHT_LUX, UnitOfSpeed, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -24,6 +27,16 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import CONF_SERIAL, DOMAIN
 
 SENSOR_DESCRIPTIONS = {
+    "BrightnessSensor": {
+        "device_class": BrightnessSensor,
+        "value_attribute": "state",
+        "entity_description_kwargs": {
+            "device_class": SensorDeviceClass.ILLUMINANCE,
+            "native_unit_of_measurement": LIGHT_LUX,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "translation_key": "brightness_sensor",
+        },
+    },
     "MovementDetectorBrightness": {
         "device_class": MovementDetector,
         "value_attribute": "brightness",
@@ -41,6 +54,37 @@ SENSOR_DESCRIPTIONS = {
             "device_class": SensorDeviceClass.ENUM,
             "options": [position.name for position in WindowDoorSensorPosition],
             "translation_key": "window_position",
+        },
+    },
+    "TemperatureSensor": {
+        "device_class": TemperatureSensor,
+        "value_attribute": "state",
+        "entity_description_kwargs": {
+            "device_class": SensorDeviceClass.TEMPERATURE,
+            "native_unit_of_measurement": UnitOfTemperature.CELSIUS,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "translation_key": "temperature_sensor",
+        },
+    },
+    "WindSensorSpeed": {
+        "device_class": WindSensor,
+        "value_attribute": "state",
+        "entity_description_kwargs": {
+            "device_class": SensorDeviceClass.WIND_SPEED,
+            "native_unit_of_measurement": UnitOfSpeed.METERS_PER_SECOND,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "translation_key": "wind_sensor_speed",
+        },
+    },
+    "WindSensorForce": {
+        "device_class": WindSensor,
+        "value_attribute": "force",
+        "entity_description_kwargs": {
+            "device_class": SensorDeviceClass.WIND_SPEED,
+            "native_unit_of_measurement": UnitOfSpeed.BEAUFORT,
+            "suggested_unit_of_measurement": UnitOfSpeed.BEAUFORT,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "translation_key": "wind_sensor_force",
         },
     },
 }
@@ -78,7 +122,7 @@ class FreeAtHomeSensorEntity(SensorEntity):
 
     def __init__(
         self,
-        device: MovementDetector,
+        device: BrightnessSensor | MovementDetector | TemperatureSensor | WindSensor,
         value_attribute: str,
         entity_description_kwargs: dict[str:Any],
         sysap_serial_number: str,

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -46,17 +46,29 @@
   },
   "entity": {
     "binary_sensor": {
+      "brightness_sensor": {
+        "name": "Brightness Alarm"
+      },
       "carbon_monoxide_sensor": {
         "name": "Carbon Monoxide"
       },
       "movement_detector_motion": {
         "name": "Motion"
       },
+      "rain_sensor": {
+        "name": "Rain Alarm"
+      },
       "smoke_detector": {
         "name": "Smoke Detector"
       },
       "switch_sensor": {
         "name": "Switch Sensor ({channel_id})"
+      },
+      "temperature_sensor": {
+        "name": "Frost Alarm"
+      },
+      "wind_sensor": {
+        "name": "Wind Alarm"
       },
       "window_door": {
         "name": "Window/Door"
@@ -85,8 +97,20 @@
       }
     },
     "sensor": {
+      "brightness_sensor": {
+        "name": "Illuminance"
+      },
       "movement_detector_brightness": {
         "name": "Illuminance"
+      },
+      "temperature_sensor": {
+        "name": "Temperature"
+      },
+      "wind_sensor_speed": {
+        "name": "Wind Speed"
+      },
+      "wind_sensor_force": {
+        "name": "Wind Force"
       },
       "window_position": {
         "name": "Window Position",

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -46,17 +46,29 @@
     },
     "entity": {
         "binary_sensor": {
+            "brightness_sensor": {
+                "name": "Brightness Alarm"
+            },
             "carbon_monoxide_sensor": {
                 "name": "Carbon Monoxide"
             },
             "movement_detector_motion": {
                 "name": "Motion"
             },
+            "rain_sensor": {
+                "name": "Rain Alarm"
+            },
             "smoke_detector": {
                 "name": "Smoke Detector"
             },
             "switch_sensor": {
                 "name": "Switch Sensor ({channel_id})"
+            },
+            "temperature_sensor": {
+                "name": "Frost Alarm"
+            },
+            "wind_sensor": {
+                "name": "Wind Alarm"
             },
             "window_door": {
                 "name": "Window/Door"
@@ -85,8 +97,20 @@
             }
         },
         "sensor": {
+            "brightness_sensor": {
+                "name": "Illuminance"
+            },
             "movement_detector_brightness": {
                 "name": "Illuminance"
+            },
+            "temperature_sensor": {
+                "name": "Temperature"
+            },
+            "wind_sensor_speed": {
+                "name": "Wind Speed"
+            },
+            "wind_sensor_force": {
+                "name": "Wind Force"
             },
             "window_position": {
                 "name": "Window Position",


### PR DESCRIPTION
This implements all entities of a Weatherstation into HA. There is only one drawback:
The thresholds for all the alarm sensors (brightness, temperature, wind) are available in the parameters of each device-class and - at least from my perspective - it would be nice to implement them as additional attributes in HA.

But - for now - F@H doesn't send an update over the websocket when a parameter is changed through the F@H-WebGUI. So the parameters would stay in HA unchanged until the integration is reloaded (e.g. through a HA restart). That's the reason I haven't included them.

Perhaps it might be something to think about - I don't know if this is possible - to implement an automatic daily "re-discover"/"re-fetch" in the integration?