### PR TITLE
Check for SysAP version 2.6.0 or newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ The primary goal of this repository is to provide initial testing for the integr
 
 Because of this, the integration will adhere to the strict [styling and code guidelines](https://developers.home-assistant.io/docs/development_guidelines/) provided by Home Assistant.
 
+## Prerequisites
+
+There are two main prerequisites before being able to use this integration.
+
+- ABB-free@home System Access Point 2.0
+- System Access Point running version 2.6.0 or newer
+
+[ABB-free@home Local API Prerequisites](https://developer.eu.mybuildings.abb.com/fah_local/prerequisites)
+
 ## Device Support
 
 The current list of supported devices by function are:

--- a/custom_components/abbfreeathome_ci/const.py
+++ b/custom_components/abbfreeathome_ci/const.py
@@ -5,3 +5,6 @@ DOMAIN = "abbfreeathome_ci"
 # Domain Configuration
 CONF_SERIAL = "serial"
 CONF_INCLUDE_ORPHAN_CHANNELS = "include_orphan_channels"
+
+# SysAP Settings
+SYSAP_VERSION = "sysap_version"

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -34,7 +34,8 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "unsupported_sysap_version": "The current version {sysap_version} of the SysAP is not supported. Only version 2.6.0 or newer is supported."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -10,7 +10,8 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
+            "unknown": "Unexpected error",
+            "unsupported_sysap_version": "The current version {sysap_version} of the SysAP is not supported. Only version 2.6.0 or newer is supported."
         },
         "step": {
             "reconfigure": {
@@ -106,11 +107,11 @@
             "temperature_sensor": {
                 "name": "Temperature"
             },
-            "wind_sensor_speed": {
-                "name": "Wind Speed"
-            },
             "wind_sensor_force": {
                 "name": "Wind Force"
+            },
+            "wind_sensor_speed": {
+                "name": "Wind Speed"
             },
             "window_position": {
                 "name": "Window Position",


### PR DESCRIPTION
This PR will check for System Access Point 2.6.0 before proceeding with setup.

For the ZeroConf discovery, this will abandon setup and the user won't be prompted to setup a new device. For the user setup flow the user will be prompted with an error that their version is too old with the actual version they are running.

I've also added a Prerequisites section to the README to inform users of the requirements for using this integration.

closes #63 