### PR TITLE
Catch ClientConnectionError on config flow

### DIFF
--- a/custom_components/abbfreeathome_ci/config_flow.py
+++ b/custom_components/abbfreeathome_ci/config_flow.py
@@ -8,6 +8,7 @@ import logging
 from typing import Any
 
 from abbfreeathome.api import (
+    ClientConnectionError,
     ForbiddenAuthException,
     FreeAtHomeApi,
     FreeAtHomeSettings,
@@ -61,6 +62,9 @@ async def validate_settings(host: str) -> dict[str, Any]:
         await settings.load()
     except InvalidHostException:
         errors["base"] = "cannot_connect"
+    except ClientConnectionError:
+        errors["base"] = "cannot_connect"
+        _LOGGER.exception("Client Connection Error")
 
     return settings.name, settings.serial_number, errors
 
@@ -78,6 +82,9 @@ async def validate_api(host: str, username: str, password: str) -> dict[str, Any
         errors["base"] = "invalid_auth"
     except InvalidHostException:
         errors["base"] = "cannot_connect"
+    except ClientConnectionError:
+        errors["base"] = "cannot_connect"
+        _LOGGER.exception("Client Connection Error")
     except Exception:
         _LOGGER.exception("Unexpected exception")
         errors["base"] = "unknown"

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://github.com/kingsleyadam/local-abbfreeathome-hass",
   "homekit": {},
   "iot_class": "local_push",
-  "requirements": ["local-abbfreeathome==1.10.0"],
+  "requirements": ["local-abbfreeathome==1.12.0"],
   "ssdp": [],
   "version": "0.11.2",
   "zeroconf": [


### PR DESCRIPTION
Closes #65 

This will catch ClientConnectionError, throw an error to the user and logs the exception.