### PR TITLE
Fix key error on user setup flow

### DIFF
--- a/custom_components/abbfreeathome_ci/config_flow.py
+++ b/custom_components/abbfreeathome_ci/config_flow.py
@@ -123,7 +123,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # Check/Get Settings
         settings, settings_errors = await validate_settings(host=user_input[CONF_HOST])
-        if settings_errors["base"] != "cannot_connect":
+        if settings_errors.get("base") != "cannot_connect":
             self._sysap_version = settings.version
         if settings_errors:
             return self._async_show_setup_form(step_id="user", errors=settings_errors)

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "requirements": ["local-abbfreeathome==1.12.0"],
   "ssdp": [],
-  "version": "0.12.0",
+  "version": "0.12.1",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",


### PR DESCRIPTION
If there are no errors a key error would get thrown trying to lookup the "base" errors. Use dict `get` function which will return a `None` type value.