### PR TITLE
Use term ABB-free@home

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Home Assistant Integration - ABB-free@home
 
-This is a custom component to integrate with [Home Assistant](https://www.home-assistant.io/) for the Busch Jaeger/ABB-free@home system over the **local api server**.
+This is a custom component to integrate with [Home Assistant](https://www.home-assistant.io/) for the Busch/ABB-free@home system over the **local api server**.
 
 The primary goal of this repository is to provide initial testing for the integration into Home Assistant. The ultimate goal of this integration is to be merged into the Home Assistant code as a built-in integration.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Home Assistant Integration - ABB-free@home
+# Home Assistant Integration - Busch/ABB-free@home
 
 This is a custom component to integrate with [Home Assistant](https://www.home-assistant.io/) for the Busch/ABB-free@home system over the **local api server**.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Home Assistant Integration - ABB Free@Home via Local Api
+# Home Assistant Integration - ABB-free@home
 
-This is a custom component to integrate with [Home Assistant](https://www.home-assistant.io/) for the Busch Jaeger/ABB Free@Home system over the **local api server**.
+This is a custom component to integrate with [Home Assistant](https://www.home-assistant.io/) for the Busch Jaeger/ABB-free@home system over the **local api server**.
 
 The primary goal of this repository is to provide initial testing for the integration into Home Assistant. The ultimate goal of this integration is to be merged into the Home Assistant code as a built-in integration.
 
@@ -19,26 +19,25 @@ There are two main prerequisites before being able to use this integration.
 
 The current list of supported devices by function are:
 
-| Function | Platform(s) |
-|--|--|
-| FID_SWITCH_ACTUATOR | `Switch` |
-| FID_SWITCH_SENSOR | `Binary Sensor`, `Event` |
-| FID_MOVEMENT_DETECTOR | `Binary Sensor`, `Sensor` |
-| FID_DIMMING_ACTUATOR | `Light` |
-| FID_WINDOW_DOOR_SENSOR | `Binary Sensor` |
+| Function                        | Platform(s)               |
+| ------------------------------- | ------------------------- |
+| FID_SWITCH_ACTUATOR             | `Switch`                  |
+| FID_SWITCH_SENSOR               | `Binary Sensor`, `Event`  |
+| FID_MOVEMENT_DETECTOR           | `Binary Sensor`, `Sensor` |
+| FID_DIMMING_ACTUATOR            | `Light`                   |
+| FID_WINDOW_DOOR_SENSOR          | `Binary Sensor`           |
 | FID_WINDOW_DOOR_POSITION_SENSOR | `Binary Sensor`, `Sensor` |
-| FID_SMOKE_DETECTOR | `Binary Sensor` |
-| FID_CARBON_MONOXIDE_SENSOR | `Binary Sensor` |
-| FID_TRIGGER | `Button` |
-| FID_BRIGHTNESS_SENSOR | `Binary Sensor`, `Sensor` |
-| FID_RAIN_SENSOR | `Binary Sensor` |
-| FID_TEMPERATURE_SENSOR | `Binary Sensor`, `Sensor` |
-| FID_WIND_SENSOR | `Binary Sensor`, `Sensor` |
-
+| FID_SMOKE_DETECTOR              | `Binary Sensor`           |
+| FID_CARBON_MONOXIDE_SENSOR      | `Binary Sensor`           |
+| FID_TRIGGER                     | `Button`                  |
+| FID_BRIGHTNESS_SENSOR           | `Binary Sensor`, `Sensor` |
+| FID_RAIN_SENSOR                 | `Binary Sensor`           |
+| FID_TEMPERATURE_SENSOR          | `Binary Sensor`, `Sensor` |
+| FID_WIND_SENSOR                 | `Binary Sensor`, `Sensor` |
 
 ### Additional Devices
 
-This is a new repo written from the ground up in tandem with the PyPi Package [local-abbfreeathome](https://pypi.org/project/local-abbfreeathome/#description) in order to communicate with the ABB Free@Home System over the **local** api. **The list of supported functions may not include your device.** If you expect a device to appear and don't, please open a new issues and include the device configuration. To fetch your device configuration download the integration [diagnostics](#download-diagnostics).
+This is a new repo written from the ground up in tandem with the PyPi Package [local-abbfreeathome](https://pypi.org/project/local-abbfreeathome/#description) in order to communicate with the ABB-free@home System over the **local** api. **The list of supported functions may not include your device.** If you expect a device to appear and don't, please open a new issues and include the device configuration. To fetch your device configuration download the integration [diagnostics](#download-diagnostics).
 
 I (kingsleyadam) don't have access to the number of different ABB devices and would rely on others to either provide configurations, or contribute code directly in order to add additional device support.
 
@@ -48,20 +47,20 @@ I (kingsleyadam) don't have access to the number of different ABB devices and wo
 
 The easiest way to add this custom integration is via HACS which the repo has been setup to support. With HACS setup on your Home Assistant installation you'll need to add this repo it as a [custom repository](https://www.hacs.xyz/docs/faq/custom_repositories/).
 
-Once added you'll be able to find it by searching for "Busch Jaeger/ABB Free@Home (Local API)".
+Once added you'll be able to find it by searching for "ABB-free@home".
 
 ### Manually
 
 1. Clone the code locally and copy all the files in `custom_components/abbfreeathome_ci` to your Home Assistant directory `./config/custom_components/abbfreeathome_ci`
 2. Restart Home Assistant
-3. You should be able to add a new integration "Busch Jaeger/ABB Free@Home (Local API)".
+3. You should be able to add a new integration "ABB-free@home".
 4. Follow the UI configuration to add the integration to your instance.
 
 ## Configuration
 
 ### Local API, Credentials
 
-Before you can setup this integration you must turn on the local API on your ABB Free@Home SysAP. More information about the local api can be found on the ABB site [here](https://developer.eu.mybuildings.abb.com/fah_local).
+Before you can setup this integration you must turn on the local API on your ABB-free@home SysAP. More information about the local api can be found on the ABB site [here](https://developer.eu.mybuildings.abb.com/fah_local).
 
 Navigate to: `SysAP Configuration` > `Settings` > `free@home - Settings` > `Local API` > `Activate Local API`
 
@@ -73,35 +72,35 @@ Copy the username listed within that window (usually `installer`) to be used whe
 
 The config setup will include some options to help configure the integration.
 
-| Configuration | Description |
-| ----------- | ----------- |
-| Hostname | **Only available in Manual (User) Setup.** The full hostname including schema of the ABB Free@Home SysAP endpoint. |
-| Username | The **api** username, likely different from your normal login username. |
-| Password | The password for logging into the SysAP. |
-| Include channels NOT on the Free@Home floorplan? | Whether to include channels that are not located on the Free@Home floorplan. |
+| Configuration                                    | Description                                                                                                        |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| Hostname                                         | **Only available in Manual (User) Setup.** The full hostname including schema of the ABB-free@home SysAP endpoint. |
+| Username                                         | The **api** username, likely different from your normal login username.                                            |
+| Password                                         | The password for logging into the SysAP.                                                                           |
+| Include channels NOT on the free@home floorplan? | Whether to include channels that are not located on the free@home floorplan.                                       |
 
 ###### Example
 
 - **Hostname**: `http://192.168.1.100`
 - **Username**: `installer`
 - **Password**: `<password>`
-- **Include channels NOT on the Free@Home floorplan?**: False
+- **Include channels NOT on the free@home floorplan?**: False
 
 > Note: Support for SSL is not provided yet. For a valid SSL connection a cert pulled from the SysAP must be provided, research to be done to know if Home Assistant supports such a scenario.
 
 #### SysAP Discovery
 
-In most installations the integration will find your Free@Home SysAP automatically on the network. After you've installed the integration and restarted Home Assistant you should see your SysAP as a new device to be setup. The hostname will automatically be discovered, you just need to enter your **api** username, password, and whether to include channels not in the floorplan to confirm the setup.
+In most installations the integration will find your free@home SysAP automatically on the network. After you've installed the integration and restarted Home Assistant you should see your SysAP as a new device to be setup. The hostname will automatically be discovered, you just need to enter your **api** username, password, and whether to include channels not in the floorplan to confirm the setup.
 
 #### Manual (User) Setup
 
-If the SysAP is not found automatically you can add it manually. Add this integration by searching for and clicking on `Busch Jaeger/ABB Free@Home (Local API)`.
+If the SysAP is not found automatically you can add it manually. Add this integration by searching for and clicking on `ABB-free@home`.
 
 When adding the integration manually you'll be prompted with all fields. The hostname must be the fully resolvable hostname with protocol (e.g. http). Adding the integration will fail if you just provide the IP address or hostname.
 
 ### Automatic Area Discovery
 
-When adding the integration it'll automatically add devices to different `Areas` in Home Assistant. The areas will be pulled from your ABB Free@Home Configuration/Floorplan. When prompted to add the devices double check the area for each.
+When adding the integration it'll automatically add devices to different `Areas` in Home Assistant. The areas will be pulled from your ABB-free@home Configuration/Floorplan. When prompted to add the devices double check the area for each.
 
 ## Events
 
@@ -109,11 +108,11 @@ When adding the integration it'll automatically add devices to different `Areas`
 
 The Switch Sensors can be deceiving. These are additional On/Off sensors associated with a switching device. If you physically toggle the switch sensor (On or Off), the status of the switch sensor will be updated in Home Assistant accordingly.
 
-However, if you turn off the light using Home Assistant, the Free@Home app, or any other non-physical method, the switch sensor will not be updated to reflect the light's status.
+However, if you turn off the light using Home Assistant, the free@home app, or any other non-physical method, the switch sensor will not be updated to reflect the light's status.
 
 This discrepancy can cause issues when automating a light. If the light is already turned off via Home Assistant, but the switch sensor still indicates an `On` state, you won't be able to turn the light on using the switch sensor.
 
->**It is best to associate a switch directly with a light in the Free@Home configuration whenever possible. For example, if you have a Philips Hue bulb, it's advisable to set up Philips Hue lights within Free@Home and associate a switch with it directly. This approach avoids using Home Assistant entirely, making the setup much more straightforward and responsive.**
+> **It is best to associate a switch directly with a light in the free@home configuration whenever possible. For example, if you have a Philips Hue bulb, it's advisable to set up Philips Hue lights within free@home and associate a switch with it directly. This approach avoids using Home Assistant entirely, making the setup much more straightforward and responsive.**
 
 If you want to control a device or a set of devices using the switch sensor in Home Assistant, it's best to use emitted events. The `SwitchSensor` class will emit an event when pressed.
 
@@ -170,7 +169,6 @@ You can enable more verbose logging within your Home Assistant installation just
 
 By default the Home Assistant default logger is `warning`, this configuration won't change that. But it'll create additional logs for both this integration and the PyPi module running a number of calls to the SysAP.
 
-
 ```yaml
 logger:
   default: warning
@@ -185,6 +183,6 @@ If you request help via GitHub [Discussions](https://github.com/kingsleyadam/loc
 
 The [diagnostics](https://www.home-assistant.io/docs/configuration/troubleshooting/#download-diagnostics) will share some information about your Home Assistant installation and this integration's installation.
 
-To pull the diagnostics about this integration navigate to the integration under `Settings` --> `Devices & Services` --> `Busch Jaeger/ABB Free@Home (Local API)`. Click the 3 dots next to the integration entity and click `Download Diagnostics`. Private information should be redacted from the download, but it's always good to double check the output before sending.
+To pull the diagnostics about this integration navigate to the integration under `Settings` --> `Devices & Services` --> `ABB-free@home`. Click the 3 dots next to the integration entity and click `Download Diagnostics`. Private information should be redacted from the download, but it's always good to double check the output before sending.
 
 Along with the `home_assistant` and `integration_manifest` you should also see `data` which includes your SysAP configuration and devices.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Home Assistant Integration - Busch/ABB-free@home
+# Home Assistant Integration - ABB-free@home
 
-This is a custom component to integrate with [Home Assistant](https://www.home-assistant.io/) for the Busch/ABB-free@home system over the **local api server**.
+This is a custom component to integrate with [Home Assistant](https://www.home-assistant.io/) for the ABB-free@home system over the **local api server**.
 
 The primary goal of this repository is to provide initial testing for the integration into Home Assistant. The ultimate goal of this integration is to be merged into the Home Assistant code as a built-in integration.
 

--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -1,4 +1,4 @@
-"""The ABB free@home integration."""
+"""The ABB-free@home integration."""
 
 from __future__ import annotations
 
@@ -28,9 +28,9 @@ PLATFORMS: list[Platform] = [
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up ABB free@home from a config entry."""
+    """Set up ABB-free@home from a config entry."""
 
-    # Get settings from Free@Home SysAP
+    # Get settings from free@home SysAP
     _free_at_home_settings = FreeAtHomeSettings(host=entry.data[CONF_HOST])
     await _free_at_home_settings.load()
 

--- a/custom_components/abbfreeathome_ci/binary_sensor.py
+++ b/custom_components/abbfreeathome_ci/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Create ABB Free@Home binary sensor entities."""
+"""Create ABB-free@home binary sensor entities."""
 
 from typing import Any
 
@@ -125,7 +125,7 @@ async def async_setup_entry(
 
 
 class FreeAtHomeBinarySensorEntity(BinarySensorEntity):
-    """Defines a Free@Home binary sensor entity."""
+    """Defines a free@home binary sensor entity."""
 
     _attr_should_poll: bool = False
     _attr_has_entity_name: bool = True

--- a/custom_components/abbfreeathome_ci/button.py
+++ b/custom_components/abbfreeathome_ci/button.py
@@ -1,4 +1,4 @@
-"""Create ABB Free@Home button entities."""
+"""Create ABB-free@home button entities."""
 
 from abbfreeathome.devices.trigger import Trigger
 from abbfreeathome.freeathome import FreeAtHome
@@ -27,7 +27,7 @@ async def async_setup_entry(
 
 
 class FreeAtHomeButtonEntity(ButtonEntity):
-    """Defines a Free@Home button entity."""
+    """Defines a free@home button entity."""
 
     _attr_should_poll: bool = False
 

--- a/custom_components/abbfreeathome_ci/config_flow.py
+++ b/custom_components/abbfreeathome_ci/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for ABB free@home integration."""
+"""Config flow for ABB-free@home integration."""
 
 from __future__ import annotations
 
@@ -97,7 +97,7 @@ async def validate_api(host: str, username: str, password: str) -> dict[str, Any
 
 
 class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for ABB free@home."""
+    """Handle a config flow for ABB-free@home."""
 
     VERSION = 1
     MINOR_VERSION = 2

--- a/custom_components/abbfreeathome_ci/const.py
+++ b/custom_components/abbfreeathome_ci/const.py
@@ -1,4 +1,4 @@
-"""Constants for the ABB free@home integration."""
+"""Constants for the ABB-free@home integration."""
 
 DOMAIN = "abbfreeathome_ci"
 

--- a/custom_components/abbfreeathome_ci/diagnostics.py
+++ b/custom_components/abbfreeathome_ci/diagnostics.py
@@ -1,4 +1,4 @@
-"""Diagnostics support for ABB Free@Home."""
+"""Diagnostics support for ABB-free@home."""
 
 from __future__ import annotations
 

--- a/custom_components/abbfreeathome_ci/event.py
+++ b/custom_components/abbfreeathome_ci/event.py
@@ -1,4 +1,4 @@
-"""Create ABB Free@Home event entities."""
+"""Create ABB-free@home event entities."""
 
 from typing import Any
 
@@ -64,7 +64,7 @@ async def async_setup_entry(
 
 
 class FreeAtHomeEventEntity(EventEntity):
-    """Free@Home Event Entity."""
+    """free@home Event Entity."""
 
     _attr_has_entity_name: bool = True
 

--- a/custom_components/abbfreeathome_ci/light.py
+++ b/custom_components/abbfreeathome_ci/light.py
@@ -1,4 +1,4 @@
-"""Create ABB Free@Home light entities."""
+"""Create ABB-free@home light entities."""
 
 from typing import Any
 
@@ -37,7 +37,7 @@ async def async_setup_entry(
 
 
 class FreeAtHomeLightEntity(LightEntity):
-    """Defines a Free@Home light entity."""
+    """Defines a free@home light entity."""
 
     _attr_should_poll: bool = False
 

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "requirements": ["local-abbfreeathome==1.12.0"],
   "ssdp": [],
-  "version": "0.12.1",
+  "version": "0.12.2",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "abbfreeathome_ci",
-  "name": "Busch/ABB-free@home",
+  "name": "ABB-free@home",
   "codeowners": ["@kingsleyadam"],
   "config_flow": true,
   "dependencies": [],

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "abbfreeathome_ci",
-  "name": "Busch Jaeger/ABB Free@Home (Local API)",
+  "name": "ABB-free@home",
   "codeowners": ["@kingsleyadam"],
   "config_flow": true,
   "dependencies": [],

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "abbfreeathome_ci",
-  "name": "ABB-free@home",
+  "name": "Busch/ABB-free@home",
   "codeowners": ["@kingsleyadam"],
   "config_flow": true,
   "dependencies": [],

--- a/custom_components/abbfreeathome_ci/sensor.py
+++ b/custom_components/abbfreeathome_ci/sensor.py
@@ -1,4 +1,4 @@
-"""Create ABB Free@Home sensor entities."""
+"""Create ABB-free@home sensor entities."""
 
 from typing import Any
 
@@ -115,7 +115,7 @@ async def async_setup_entry(
 
 
 class FreeAtHomeSensorEntity(SensorEntity):
-    """Defines a Free@Home sensor entity."""
+    """Defines a free@home sensor entity."""
 
     _attr_should_poll: bool = False
     _attr_has_entity_name: bool = True

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -2,32 +2,32 @@
   "config": {
     "step": {
       "user": {
-        "title": "Free@Home - Configure",
-        "description": "Enter the hostname/ip address (with schema, e.g. http://), username, and password of your Free@Home SysAP to integrate with Home Assistant.",
+        "title": "ABB-free@home - Configure",
+        "description": "Enter the hostname/ip address (with schema, e.g. http://), username, and password of your ABB-free@home SysAP to integrate with Home Assistant.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "include_orphan_channels": "Include channels NOT on the Free@Home floorplan?"
+          "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?"
         }
       },
       "zeroconf_confirm": {
-        "title": "Free@Home - Confirm",
+        "title": "ABB-free@home - Confirm",
         "description": "Do you want to set up {name} ({serial}) at {host}?",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "include_orphan_channels": "Include channels NOT on the Free@Home floorplan?"
+          "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?"
         }
       },
       "reconfigure": {
-        "title": "Free@Home - Reconfigure",
+        "title": "ABB-free@home - Reconfigure",
         "description": "Do you want reconfigure {name} ({serial}) at {host}?",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "include_orphan_channels": "Include channels NOT on the Free@Home floorplan?"
+          "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?"
         }
       }
     },

--- a/custom_components/abbfreeathome_ci/switch.py
+++ b/custom_components/abbfreeathome_ci/switch.py
@@ -1,4 +1,4 @@
-"""Create ABB Free@Home switch entities."""
+"""Create ABB-free@home switch entities."""
 
 from typing import Any
 
@@ -33,7 +33,7 @@ async def async_setup_entry(
 
 
 class FreeAtHomeSwitchEntity(SwitchEntity):
-    """Defines a Free@Home switch entity."""
+    """Defines a free@home switch entity."""
 
     _attr_should_poll: bool = False
 

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -1,127 +1,127 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Device is already configured",
-            "already_in_progress": "Configuration flow is already in progress",
-            "reauth_successful": "Re-authentication was successful",
-            "reconfigure_not_supported": "Reconfigure for this integration is only supported on Home Assistant version 2024.11.0 or newer.",
-            "reconfigure_successful": "Re-configuration was successful"
-        },
-        "error": {
-            "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error",
-            "unsupported_sysap_version": "The current version {sysap_version} of the SysAP is not supported. Only version 2.6.0 or newer is supported."
-        },
-        "step": {
-            "reconfigure": {
-                "data": {
-                    "include_orphan_channels": "Include channels NOT on the Free@Home floorplan?",
-                    "password": "Password",
-                    "username": "Username"
-                },
-                "description": "Do you want reconfigure {name} ({serial}) at {host}?",
-                "title": "Free@Home - Reconfigure"
-            },
-            "user": {
-                "data": {
-                    "host": "Host",
-                    "include_orphan_channels": "Include channels NOT on the Free@Home floorplan?",
-                    "password": "Password",
-                    "username": "Username"
-                },
-                "description": "Enter the hostname/ip address (with schema, e.g. http://), username, and password of your Free@Home SysAP to integrate with Home Assistant.",
-                "title": "Free@Home - Configure"
-            },
-            "zeroconf_confirm": {
-                "data": {
-                    "host": "Host",
-                    "include_orphan_channels": "Include channels NOT on the Free@Home floorplan?",
-                    "password": "Password",
-                    "username": "Username"
-                },
-                "description": "Do you want to set up {name} ({serial}) at {host}?",
-                "title": "Free@Home - Confirm"
-            }
-        }
+  "config": {
+    "abort": {
+      "already_configured": "Device is already configured",
+      "already_in_progress": "Configuration flow is already in progress",
+      "reauth_successful": "Re-authentication was successful",
+      "reconfigure_not_supported": "Reconfigure for this integration is only supported on Home Assistant version 2024.11.0 or newer.",
+      "reconfigure_successful": "Re-configuration was successful"
     },
-    "entity": {
-        "binary_sensor": {
-            "brightness_sensor": {
-                "name": "Brightness Alarm"
-            },
-            "carbon_monoxide_sensor": {
-                "name": "Carbon Monoxide"
-            },
-            "movement_detector_motion": {
-                "name": "Motion"
-            },
-            "rain_sensor": {
-                "name": "Rain Alarm"
-            },
-            "smoke_detector": {
-                "name": "Smoke Detector"
-            },
-            "switch_sensor": {
-                "name": "Switch Sensor ({channel_id})"
-            },
-            "temperature_sensor": {
-                "name": "Frost Alarm"
-            },
-            "wind_sensor": {
-                "name": "Wind Alarm"
-            },
-            "window_door": {
-                "name": "Window/Door"
-            }
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error",
+      "unsupported_sysap_version": "The current version {sysap_version} of the SysAP is not supported. Only version 2.6.0 or newer is supported."
+    },
+    "step": {
+      "reconfigure": {
+        "data": {
+          "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
+          "password": "Password",
+          "username": "Username"
         },
-        "event": {
-            "des_door_ringing_sensor": {
-                "state_attributes": {
-                    "event_type": {
-                        "state": {
-                            "activated": "Activated"
-                        }
-                    }
-                }
-            },
-            "switch_sensor": {
-                "name": "Switch Event ({channel_id})",
-                "state_attributes": {
-                    "event_type": {
-                        "state": {
-                            "off": "Off",
-                            "on": "On"
-                        }
-                    }
-                }
-            }
+        "description": "Do you want reconfigure {name} ({serial}) at {host}?",
+        "title": "ABB-free@home - Reconfigure"
+      },
+      "user": {
+        "data": {
+          "host": "Host",
+          "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
+          "password": "Password",
+          "username": "Username"
         },
-        "sensor": {
-            "brightness_sensor": {
-                "name": "Illuminance"
-            },
-            "movement_detector_brightness": {
-                "name": "Illuminance"
-            },
-            "temperature_sensor": {
-                "name": "Temperature"
-            },
-            "wind_sensor_force": {
-                "name": "Wind Force"
-            },
-            "wind_sensor_speed": {
-                "name": "Wind Speed"
-            },
-            "window_position": {
-                "name": "Window Position",
-                "state": {
-                    "closed": "Closed",
-                    "open": "Open",
-                    "tilted": "Tilted",
-                    "unknown": "Unknown"
-                }
-            }
-        }
+        "description": "Enter the hostname/ip address (with schema, e.g. http://), username, and password of your ABB-free@home SysAP to integrate with Home Assistant.",
+        "title": "ABB-free@home - Configure"
+      },
+      "zeroconf_confirm": {
+        "data": {
+          "host": "Host",
+          "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
+          "password": "Password",
+          "username": "Username"
+        },
+        "description": "Do you want to set up {name} ({serial}) at {host}?",
+        "title": "ABB-free@home - Confirm"
+      }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "brightness_sensor": {
+        "name": "Brightness Alarm"
+      },
+      "carbon_monoxide_sensor": {
+        "name": "Carbon Monoxide"
+      },
+      "movement_detector_motion": {
+        "name": "Motion"
+      },
+      "rain_sensor": {
+        "name": "Rain Alarm"
+      },
+      "smoke_detector": {
+        "name": "Smoke Detector"
+      },
+      "switch_sensor": {
+        "name": "Switch Sensor ({channel_id})"
+      },
+      "temperature_sensor": {
+        "name": "Frost Alarm"
+      },
+      "wind_sensor": {
+        "name": "Wind Alarm"
+      },
+      "window_door": {
+        "name": "Window/Door"
+      }
+    },
+    "event": {
+      "des_door_ringing_sensor": {
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "activated": "Activated"
+            }
+          }
+        }
+      },
+      "switch_sensor": {
+        "name": "Switch Event ({channel_id})",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "off": "Off",
+              "on": "On"
+            }
+          }
+        }
+      }
+    },
+    "sensor": {
+      "brightness_sensor": {
+        "name": "Illuminance"
+      },
+      "movement_detector_brightness": {
+        "name": "Illuminance"
+      },
+      "temperature_sensor": {
+        "name": "Temperature"
+      },
+      "wind_sensor_force": {
+        "name": "Wind Force"
+      },
+      "wind_sensor_speed": {
+        "name": "Wind Speed"
+      },
+      "window_position": {
+        "name": "Window Position",
+        "state": {
+          "closed": "Closed",
+          "open": "Open",
+          "tilted": "Tilted",
+          "unknown": "Unknown"
+        }
+      }
+    }
+  }
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-  "name": "ABB-free@home",
+  "name": "Busch/ABB-free@home",
   "render_readme": true
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-    "name": "Busch Jaeger/ABB Free@Home (Local API)",
-    "render_readme": true
+  "name": "ABB-free@home",
+  "render_readme": true
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-  "name": "Busch/ABB-free@home",
+  "name": "ABB-free@home",
   "render_readme": true
 }


### PR DESCRIPTION
This is purely a documentation update.

- Updates any reference to the free@home brand to `Busch/ABB-free@home` to match-up with ABB branding. They seem to have two different namings, probably depending on region?
  - Internally I've just referenced ABB-free@home. The title of the integration and name in hacs as `Busch/ABB-free@home`.
  - https://www.busch-jaeger.nl/producten/systemen/busch-freehome
  - https://new.abb.com/low-voltage/products/building-automation/product-range/abb-freeathome