### PR TITLE
Implement BlindSensor

### DIFF
--- a/custom_components/abbfreeathome_ci/binary_sensor.py
+++ b/custom_components/abbfreeathome_ci/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from abbfreeathome.devices.blind_sensor import BlindSensor
 from abbfreeathome.devices.brightness_sensor import BrightnessSensor
 from abbfreeathome.devices.carbon_monoxide_sensor import CarbonMonoxideSensor
 from abbfreeathome.devices.movement_detector import MovementDetector
@@ -55,6 +56,20 @@ SENSOR_DESCRIPTIONS = {
         "value_attribute": "state",
         "entity_description_kwargs": {
             "translation_key": "switch_sensor",
+        },
+    },
+    "BlindSensorShort": {
+        "device_class": BlindSensor,
+        "value_attribute": "state",
+        "entity_description_kwargs": {
+            "translation_key": "blind_sensor_short",
+        },
+    },
+    "BlindSensorLong": {
+        "device_class": BlindSensor,
+        "value_attribute": "longpress",
+        "entity_description_kwargs": {
+            "translation_key": "blind_sensor_long",
         },
     },
     "WindowDoorSensorOnOff": {

--- a/custom_components/abbfreeathome_ci/event.py
+++ b/custom_components/abbfreeathome_ci/event.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from abbfreeathome.devices.blind_sensor import BlindSensor
 from abbfreeathome.devices.des_door_ringing_sensor import DesDoorRingingSensor
 from abbfreeathome.devices.switch_sensor import SwitchSensor
 from abbfreeathome.freeathome import FreeAtHome
@@ -26,6 +27,24 @@ EVENT_DESCRIPTIONS = {
             "device_class": EventDeviceClass.BUTTON,
             "event_types": ["on", "off"],
             "translation_key": "switch_sensor",
+        },
+    },
+    "EventBlindSensorShort": {
+        "device_class": BlindSensor,
+        "event_type_callback": lambda state: "on" if state else "off",
+        "entity_description_kwargs": {
+            "device_class": EventDeviceClass.BUTTON,
+            "event_types": ["on", "off"],
+            "translation_key": "blind_sensor_short",
+        },
+    },
+    "EventBlindSensorLong": {
+        "device_class": BlindSensor,
+        "event_type_callback": lambda longpress: "on" if longpress else "off",
+        "entity_description_kwargs": {
+            "device_class": EventDeviceClass.BUTTON,
+            "event_types": ["on", "off"],
+            "translation_key": "blind_sensor_long",
         },
     },
     "DesDoorRingingSensorActivated": {

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://github.com/kingsleyadam/local-abbfreeathome-hass",
   "homekit": {},
   "iot_class": "local_push",
-  "requirements": ["local-abbfreeathome==1.12.0"],
+  "requirements": ["local-abbfreeathome==1.13.1"],
   "ssdp": [],
   "version": "0.12.2",
   "zeroconf": [

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -65,6 +65,12 @@
       "switch_sensor": {
         "name": "Switch Sensor ({channel_id})"
       },
+      "blind_sensor_short": {
+        "name": "Blind Sensor Short ({channel_id})"
+      },
+      "blind_sensor_long": {
+        "name": "Blind Sensor Long ({channel_id})"
+      },
       "temperature_sensor": {
         "name": "Frost Alarm"
       },
@@ -78,6 +84,28 @@
     "event": {
       "switch_sensor": {
         "name": "Switch Event ({channel_id})",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "on": "[%key:common::state::on%]",
+              "off": "[%key:common::state::off%]"
+            }
+          }
+        }
+      },
+      "blind_sensor_short": {
+        "name": "Blind Event Short ({channel_id})",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "on": "[%key:common::state::on%]",
+              "off": "[%key:common::state::off%]"
+            }
+          }
+        }
+      },
+      "blind_sensor_long": {
+        "name": "Blind Event Long ({channel_id})",
         "state_attributes": {
           "event_type": {
             "state": {

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -65,6 +65,12 @@
       "switch_sensor": {
         "name": "Switch Sensor ({channel_id})"
       },
+      "blind_sensor_short": {
+        "name": "Blind Sensor Short ({channel_id})"
+      },
+      "blind_sensor_long": {
+        "name": "Blind Sensor Long ({channel_id})"
+      },
       "temperature_sensor": {
         "name": "Frost Alarm"
       },
@@ -87,6 +93,28 @@
       },
       "switch_sensor": {
         "name": "Switch Event ({channel_id})",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "off": "Off",
+              "on": "On"
+            }
+          }
+        }
+      },
+      "blind_sensor_short": {
+        "name": "Blind Event Short ({channel_id})",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "off": "Off",
+              "on": "On"
+            }
+          }
+        }
+      },
+      "blind_sensor_long": {
+        "name": "Blind Event Long ({channel_id})",
         "state_attributes": {
           "event_type": {
             "state": {


### PR DESCRIPTION
closes #73 

@kingsleyadam : Can you please have a look at this implementation. The long- and short-press events are always fired together, doesn't matter if press the rocker short or long. The sensors are correct.
Can it be that all registered events of a device-class are always fired?