### PR TITLE
Add new events/adjust, remove binary sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Home Assistant Integration - ABB-free@home
 
+![GitHub Release](https://img.shields.io/github/v/release/kingsleyadam/local-abbfreeathome-hass) ![hassfest](https://github.com/kingsleyadam/local-abbfreeathome-hass/actions/workflows/hassfest.yaml/badge.svg) [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 This is a custom component to integrate with [Home Assistant](https://www.home-assistant.io/) for the ABB-free@home system over the **local api server**.
 
-The primary goal of this repository is to provide initial testing for the integration into Home Assistant. The ultimate goal of this integration is to be merged into the Home Assistant code as a built-in integration.
+The primary goal of this repository is to provide initial development for the integration into Home Assistant. The ultimate goal of this integration is to be merged into the Home Assistant code as a built-in integration.
 
 Because of this, the integration will adhere to the strict [styling and code guidelines](https://developers.home-assistant.io/docs/development_guidelines/) provided by Home Assistant.
 
@@ -21,19 +23,23 @@ The current list of supported devices by function are:
 
 | Function                        | Platform(s)               |
 | ------------------------------- | ------------------------- |
-| FID_SWITCH_ACTUATOR             | `Switch`                  |
-| FID_SWITCH_SENSOR               | `Binary Sensor`, `Event`  |
-| FID_MOVEMENT_DETECTOR           | `Binary Sensor`, `Sensor` |
+| FID_BLIND_SENSOR                | `Event`                   |
+| FID_BRIGHTNESS_SENSOR           | `Binary Sensor`, `Sensor` |
+| FID_CARBON_MONOXIDE_SENSOR      | `Binary Sensor`           |
 | FID_DIMMING_ACTUATOR            | `Light`                   |
+| FID_DIMMING_SENSOR              | `Event`                   |
+| FID_FORCE_ON_OFF_SENSOR         | `Event`                   |
+| FID_HEATING_ACTUATOR            | `Valve`                   |
+| FID_RAIN_SENSOR                 | `Binary Sensor`           |
+| FID_SMOKE_DETECTOR              | `Binary Sensor`           |
+| FID_SWITCH_ACTUATOR             | `Switch`                  |
+| FID_SWITCH_SENSOR               | `Event`                   |
+| FID_TEMPERATURE_SENSOR          | `Binary Sensor`, `Sensor` |
+| FID_TRIGGER                     | `Button`                  |
+| FID_MOVEMENT_DETECTOR           | `Binary Sensor`, `Sensor` |
+| FID_WIND_SENSOR                 | `Binary Sensor`, `Sensor` |
 | FID_WINDOW_DOOR_SENSOR          | `Binary Sensor`           |
 | FID_WINDOW_DOOR_POSITION_SENSOR | `Binary Sensor`, `Sensor` |
-| FID_SMOKE_DETECTOR              | `Binary Sensor`           |
-| FID_CARBON_MONOXIDE_SENSOR      | `Binary Sensor`           |
-| FID_TRIGGER                     | `Button`                  |
-| FID_BRIGHTNESS_SENSOR           | `Binary Sensor`, `Sensor` |
-| FID_RAIN_SENSOR                 | `Binary Sensor`           |
-| FID_TEMPERATURE_SENSOR          | `Binary Sensor`, `Sensor` |
-| FID_WIND_SENSOR                 | `Binary Sensor`, `Sensor` |
 
 ### Additional Devices
 
@@ -45,7 +51,7 @@ I (kingsleyadam) don't have access to the number of different ABB devices and wo
 
 ### HACS
 
-The easiest way to add this custom integration is via HACS which the repo has been setup to support. With HACS setup on your Home Assistant installation you'll need to add this repo it as a [custom repository](https://www.hacs.xyz/docs/faq/custom_repositories/).
+The easiest way to add this custom integration is via [HACS](https://www.hacs.xyz/) which the repo has been setup to support. With HACS setup on your Home Assistant installation you'll need to add this repo it as a [custom repository](https://www.hacs.xyz/docs/faq/custom_repositories/).
 
 Once added you'll be able to find it by searching for "ABB-free@home".
 
@@ -127,14 +133,14 @@ triggers:
   - trigger: state
     entity_id:
       - event.study_area_rocker_switch_event
-    to: "Off"
+    to: 'Off'
     attribute: event_type
     id: study_area_event_off
   - trigger: state
     entity_id:
       - event.study_area_rocker_switch_event
     attribute: event_type
-    to: "On"
+    to: 'On'
     id: study_area_event_on
 conditions: []
 actions:

--- a/custom_components/abbfreeathome_ci/binary_sensor.py
+++ b/custom_components/abbfreeathome_ci/binary_sensor.py
@@ -4,11 +4,9 @@ from typing import Any
 
 from abbfreeathome.devices.brightness_sensor import BrightnessSensor
 from abbfreeathome.devices.carbon_monoxide_sensor import CarbonMonoxideSensor
-from abbfreeathome.devices.force_on_off_sensor import ForceOnOffSensor
 from abbfreeathome.devices.movement_detector import MovementDetector
 from abbfreeathome.devices.rain_sensor import RainSensor
 from abbfreeathome.devices.smoke_detector import SmokeDetector
-from abbfreeathome.devices.switch_sensor import SwitchSensor
 from abbfreeathome.devices.temperature_sensor import TemperatureSensor
 from abbfreeathome.devices.wind_sensor import WindSensor
 from abbfreeathome.devices.window_door_sensor import WindowDoorSensor
@@ -49,20 +47,6 @@ SENSOR_DESCRIPTIONS = {
         "entity_description_kwargs": {
             "device_class": BinarySensorDeviceClass.SMOKE,
             "translation_key": "smoke_detector",
-        },
-    },
-    "SwitchSensorOnOff": {
-        "device_class": SwitchSensor,
-        "value_attribute": "state",
-        "entity_description_kwargs": {
-            "translation_key": "switch_sensor",
-        },
-    },
-    "ForceOnOffSensorOnOff": {
-        "device_class": ForceOnOffSensor,
-        "value_attribute": "state",
-        "entity_description_kwargs": {
-            "translation_key": "force_on_off_sensor",
         },
     },
     "WindowDoorSensorOnOff": {
@@ -145,7 +129,6 @@ class FreeAtHomeBinarySensorEntity(BinarySensorEntity):
         | MovementDetector
         | RainSensor
         | SmokeDetector
-        | SwitchSensor
         | TemperatureSensor
         | WindowDoorSensor
         | WindSensor,

--- a/custom_components/abbfreeathome_ci/event.py
+++ b/custom_components/abbfreeathome_ci/event.py
@@ -2,9 +2,18 @@
 
 from typing import Any
 
+from abbfreeathome.devices.blind_sensor import BlindSensor, BlindSensorState
 from abbfreeathome.devices.des_door_ringing_sensor import DesDoorRingingSensor
-from abbfreeathome.devices.force_on_off_sensor import ForceOnOffSensor
-from abbfreeathome.devices.switch_sensor import SwitchSensor
+from abbfreeathome.devices.force_on_off_sensor import (
+    ForceOnOffSensor,
+    ForceOnOffSensorState,
+)
+from abbfreeathome.devices.switch_sensor import (
+    DimmingSensor,
+    DimmingSensorState,
+    SwitchSensor,
+    SwitchSensorState,
+)
 from abbfreeathome.freeathome import FreeAtHome
 
 from homeassistant.components.event import (
@@ -20,31 +29,54 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import CONF_SERIAL, DOMAIN
 
 EVENT_DESCRIPTIONS = {
-    "EventSwitchSensorOnOff": {
-        "device_class": SwitchSensor,
-        "event_type_callback": lambda state: "on" if state else "off",
+    "EventBlindSensorState": {
+        "device_class": BlindSensor,
+        "event_type_callback": lambda state: state,
         "entity_description_kwargs": {
             "device_class": EventDeviceClass.BUTTON,
-            "event_types": ["on", "off"],
-            "translation_key": "switch_sensor",
+            "event_types": [state.name for state in BlindSensorState],
+            "translation_key": "blind_sensor",
         },
     },
-    "EventForceOnOffSensorOnOff": {
-        "device_class": ForceOnOffSensor,
-        "event_type_callback": lambda state: "on" if state else "off",
-        "entity_description_kwargs": {
-            "device_class": EventDeviceClass.BUTTON,
-            "event_types": ["on", "off"],
-            "translation_key": "force_on_off_sensor",
-        },
-    },
-    "DesDoorRingingSensorActivated": {
+    "EventDesDoorRingingSensorActivated": {
         "device_class": DesDoorRingingSensor,
         "event_type_callback": lambda: "activated",
         "entity_description_kwargs": {
             "device_class": EventDeviceClass.BUTTON,
             "event_types": ["activated"],
             "translation_key": "des_door_ringing_sensor",
+        },
+    },
+    "EventDimmingSensorState": {
+        "device_class": DimmingSensor,
+        "event_type_callback": lambda state: state,
+        "entity_description_kwargs": {
+            "device_class": EventDeviceClass.BUTTON,
+            "event_types": list(
+                set(
+                    [state.name for state in SwitchSensorState]
+                    + [state.name for state in DimmingSensorState]
+                )
+            ),
+            "translation_key": "dimming_sensor",
+        },
+    },
+    "EventForceOnOffSensorOnOff": {
+        "device_class": ForceOnOffSensor,
+        "event_type_callback": lambda state: state,
+        "entity_description_kwargs": {
+            "device_class": EventDeviceClass.BUTTON,
+            "event_types": [state.name for state in ForceOnOffSensorState],
+            "translation_key": "force_on_off_sensor",
+        },
+    },
+    "EventSwitchSensorOnOff": {
+        "device_class": SwitchSensor,
+        "event_type_callback": lambda state: state,
+        "entity_description_kwargs": {
+            "device_class": EventDeviceClass.BUTTON,
+            "event_types": [state.name for state in SwitchSensorState],
+            "translation_key": "switch_sensor",
         },
     },
 }

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://github.com/kingsleyadam/local-abbfreeathome-hass",
   "homekit": {},
   "iot_class": "local_push",
-  "requirements": ["local-abbfreeathome==1.14.0"],
+  "requirements": ["local-abbfreeathome==1.14.1"],
   "ssdp": [],
   "version": "0.12.2",
   "zeroconf": [

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://github.com/kingsleyadam/local-abbfreeathome-hass",
   "homekit": {},
   "iot_class": "local_push",
-  "requirements": ["local-abbfreeathome==1.13.1"],
+  "requirements": ["local-abbfreeathome==1.14.0"],
   "ssdp": [],
   "version": "0.12.2",
   "zeroconf": [

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -62,12 +62,6 @@
       "smoke_detector": {
         "name": "Smoke Detector"
       },
-      "switch_sensor": {
-        "name": "Switch Sensor ({channel_id})"
-      },
-      "force_on_off_sensor": {
-        "name": "Force Sensor ({channel_id})"
-      },
       "temperature_sensor": {
         "name": "Frost Alarm"
       },
@@ -79,24 +73,16 @@
       }
     },
     "event": {
-      "switch_sensor": {
-        "name": "Switch Event ({channel_id})",
+      "blind_sensor": {
+        "name": "Blind Event ({channel_id})",
         "state_attributes": {
           "event_type": {
             "state": {
-              "on": "[%key:common::state::on%]",
-              "off": "[%key:common::state::off%]"
-            }
-          }
-        }
-      },
-      "force_on_off_sensor": {
-        "name": "Force Event ({channel_id})",
-        "state_attributes": {
-          "event_type": {
-            "state": {
-              "on": "[%key:common::state::on%]",
-              "off": "[%key:common::state::off%]"
+              "unknown": "Unknown",
+              "step_up": "Step Up/Stop",
+              "step_down": "Step Down/Stop",
+              "move_up": "Move Up",
+              "move_down": "Move Down"
             }
           }
         }
@@ -106,6 +92,46 @@
           "event_type": {
             "state": {
               "activated": "Activated"
+            }
+          }
+        }
+      },
+      "dimming_sensor": {
+        "name": "Dimming Event ({channel_id})",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "unknown": "Unknown",
+              "on": "[%key:common::state::on%]",
+              "off": "[%key:common::state::off%]",
+              "longpress_up": "Dimming Up",
+              "longpress_up_release": "Dimming Up Release",
+              "longpress_down": "Dimming Down",
+              "longpress_down_release": "Dimming Down Release"
+            }
+          }
+        }
+      },
+      "force_on_off_sensor": {
+        "name": "Force Event ({channel_id})",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "unknown": "Unknown",
+              "on": "[%key:common::state::on%]",
+              "off": "[%key:common::state::off%]"
+            }
+          }
+        }
+      },
+      "switch_sensor": {
+        "name": "Switch Event ({channel_id})",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "unknown": "Unknown",
+              "on": "[%key:common::state::on%]",
+              "off": "[%key:common::state::off%]"
             }
           }
         }

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -62,12 +62,6 @@
       "smoke_detector": {
         "name": "Smoke Detector"
       },
-      "switch_sensor": {
-        "name": "Switch Sensor ({channel_id})"
-      },
-      "force_on_off_sensor": {
-        "name": "Force Sensor ({channel_id})"
-      },
       "temperature_sensor": {
         "name": "Frost Alarm"
       },
@@ -79,6 +73,20 @@
       }
     },
     "event": {
+      "blind_sensor": {
+        "name": "Blind Event ({channel_id})",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "move_down": "Move Down",
+              "move_up": "Move Up",
+              "step_down": "Step Down/Stop",
+              "step_up": "Step Up/Stop",
+              "unknown": "Unknown"
+            }
+          }
+        }
+      },
       "des_door_ringing_sensor": {
         "state_attributes": {
           "event_type": {
@@ -88,12 +96,30 @@
           }
         }
       },
+      "dimming_sensor": {
+        "name": "Dimming Event ({channel_id})",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "longpress_down": "Dimming Down",
+              "longpress_down_release": "Dimming Down Release",
+              "longpress_up": "Dimming Up",
+              "longpress_up_release": "Dimming Up Release",
+              "off": "Off",
+              "on": "On",
+              "unknown": "Unknown"
+            }
+          }
+        }
+      },
       "force_on_off_sensor": {
+        "name": "Force Event ({channel_id})",
         "state_attributes": {
           "event_type": {
             "state": {
               "off": "Off",
-              "on": "On"
+              "on": "On",
+              "unknown": "Unknown"
             }
           }
         }
@@ -104,7 +130,8 @@
           "event_type": {
             "state": {
               "off": "Off",
-              "on": "On"
+              "on": "On",
+              "unknown": "Unknown"
             }
           }
         }


### PR DESCRIPTION
This makes a number of adjustments to events and binary sensors.

- Removes the `SwitchSensor` and `ForceOnOffSensor` from the binary_sensor as these do not make sense as sensors. They're moment in time "events" and will be treated just as events.
- Add the following new events
  - `BlindSensor`
  - `DimmingSensor`
- Also, adjust the sensors for `SwitchSensor`, `ForceOnOffSensor` to use the new state options.