### PR TITLE
Add new select platform for forced options

### DIFF
--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -23,6 +23,7 @@ PLATFORMS: list[Platform] = [
     Platform.CLIMATE,
     Platform.EVENT,
     Platform.LIGHT,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.VALVE,

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://github.com/kingsleyadam/local-abbfreeathome-hass",
   "homekit": {},
   "iot_class": "local_push",
-  "requirements": ["local-abbfreeathome==1.14.1"],
+  "requirements": ["local-abbfreeathome==1.15.0"],
   "ssdp": [],
   "version": "0.13.0",
   "zeroconf": [

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://github.com/kingsleyadam/local-abbfreeathome-hass",
   "homekit": {},
   "iot_class": "local_push",
-  "requirements": ["local-abbfreeathome==1.15.0"],
+  "requirements": ["local-abbfreeathome==1.15.1"],
   "ssdp": [],
   "version": "0.13.0",
   "zeroconf": [

--- a/custom_components/abbfreeathome_ci/select.py
+++ b/custom_components/abbfreeathome_ci/select.py
@@ -3,16 +3,19 @@
 from typing import Any
 
 from abbfreeathome.devices.cover_actuator import (
-    CoverActuator,
-    CoverActuatorForcePosition,
+    AtticWindowActuator,
+    AwningActuator,
+    BlindActuator,
+    CoverActuatorForcedPosition,
+    ShutterActuator,
 )
 from abbfreeathome.devices.dimming_actuator import (
     DimmingActuator,
-    DimmingActuatorForceState,
+    DimmingActuatorForcedPosition,
 )
 from abbfreeathome.devices.switch_actuator import (
     SwitchActuator,
-    SwitchActuatorForceState,
+    SwitchActuatorForcedPosition,
 )
 from abbfreeathome.freeathome import FreeAtHome
 
@@ -25,40 +28,79 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import CONF_SERIAL, DOMAIN
 
 SELECT_DESCRIPTIONS = {
-    "CoverActuatorForcedPosition": {
-        "device_class": CoverActuator,
+    "AtticWindowActuatorForcedPosition": {
+        "device_class": AtticWindowActuator,
         "current_option_attribute": "forced_position",
-        "select_option_method": "set_force_position",
+        "select_option_method": "set_forced_position",
         "entity_description_kwargs": {
             "options": [
                 state.name
-                for state in CoverActuatorForcePosition
+                for state in CoverActuatorForcedPosition
                 if state.value is not None
             ],
             "translation_key": "cover_actuator",
         },
     },
-    "SelectSwitchActuatorForcedPosition": {
-        "device_class": SwitchActuator,
-        "current_option_attribute": "forced",
-        "select_option_method": "set_forced",
+    "AwningActuatorForcedPosition": {
+        "device_class": AwningActuator,
+        "current_option_attribute": "forced_position",
+        "select_option_method": "set_forced_position",
         "entity_description_kwargs": {
             "options": [
                 state.name
-                for state in SwitchActuatorForceState
+                for state in CoverActuatorForcedPosition
+                if state.value is not None
+            ],
+            "translation_key": "cover_actuator",
+        },
+    },
+    "BlindActuatorForcedPosition": {
+        "device_class": BlindActuator,
+        "current_option_attribute": "forced_position",
+        "select_option_method": "set_forced_position",
+        "entity_description_kwargs": {
+            "options": [
+                state.name
+                for state in CoverActuatorForcedPosition
+                if state.value is not None
+            ],
+            "translation_key": "cover_actuator",
+        },
+    },
+    "ShutterActuatorForcedPosition": {
+        "device_class": ShutterActuator,
+        "current_option_attribute": "forced_position",
+        "select_option_method": "set_forced_position",
+        "entity_description_kwargs": {
+            "options": [
+                state.name
+                for state in CoverActuatorForcedPosition
+                if state.value is not None
+            ],
+            "translation_key": "cover_actuator",
+        },
+    },
+    "SwitchActuatorForcedPosition": {
+        "device_class": SwitchActuator,
+        "current_option_attribute": "forced_position",
+        "select_option_method": "set_forced_position",
+        "entity_description_kwargs": {
+            "options": [
+                state.name
+                for state in SwitchActuatorForcedPosition
                 if state.value is not None
             ],
             "translation_key": "switch_actuator",
         },
     },
-    "SelectDimmingActuatorForcedPosition": {
+    "DimmingActuatorForcedPosition": {
         "device_class": DimmingActuator,
-        "current_option_attribute": "forced",
-        "select_option_method": "set_forced",
+        "current_option_attribute": "forced_position",
+        "select_option_method": "set_forced_position",
         "entity_description_kwargs": {
             "options": [
                 state.name
-                for state in DimmingActuatorForceState
+                for state in DimmingActuatorForcedPosition
                 if state.value is not None
             ],
             "translation_key": "dimming_actuator",
@@ -98,7 +140,12 @@ class FreeAtHomeSelectEntity(SelectEntity):
 
     def __init__(
         self,
-        device: CoverActuator | DimmingActuator | SwitchActuator,
+        device: AtticWindowActuator
+        | AwningActuator
+        | BlindActuator
+        | DimmingActuator
+        | ShutterActuator
+        | SwitchActuator,
         entity_description_kwargs: dict[str:Any],
         current_option_attribute: str,
         select_option_method: str,
@@ -127,11 +174,6 @@ class FreeAtHomeSelectEntity(SelectEntity):
         self._device.remove_callback(self.async_write_ha_state)
 
     @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return self._device.avaiable if hasattr(self._device, "available") else True
-
-    @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
         return {
@@ -151,7 +193,7 @@ class FreeAtHomeSelectEntity(SelectEntity):
     @property
     def unique_id(self) -> str | None:
         """Return a unique ID."""
-        return f"{self._device.device_id}_{self._device.channel_id}_select"
+        return f"{self._device.device_id}_{self._device.channel_id}_{self.entity_description.key}"
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/custom_components/abbfreeathome_ci/select.py
+++ b/custom_components/abbfreeathome_ci/select.py
@@ -98,7 +98,7 @@ class FreeAtHomeSelectEntity(SelectEntity):
 
     def __init__(
         self,
-        device: SwitchActuator,
+        device: CoverActuator | DimmingActuator | SwitchActuator,
         entity_description_kwargs: dict[str:Any],
         current_option_attribute: str,
         select_option_method: str,

--- a/custom_components/abbfreeathome_ci/select.py
+++ b/custom_components/abbfreeathome_ci/select.py
@@ -1,0 +1,158 @@
+"""Create ABB-free@home switch entities."""
+
+from typing import Any
+
+from abbfreeathome.devices.cover_actuator import (
+    CoverActuator,
+    CoverActuatorForcePosition,
+)
+from abbfreeathome.devices.dimming_actuator import (
+    DimmingActuator,
+    DimmingActuatorForceState,
+)
+from abbfreeathome.devices.switch_actuator import (
+    SwitchActuator,
+    SwitchActuatorForceState,
+)
+from abbfreeathome.freeathome import FreeAtHome
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_SERIAL, DOMAIN
+
+SELECT_DESCRIPTIONS = {
+    "CoverActuatorForcedPosition": {
+        "device_class": CoverActuator,
+        "current_option_attribute": "forced_position",
+        "select_option_method": "set_force_position",
+        "entity_description_kwargs": {
+            "options": [
+                state.name
+                for state in CoverActuatorForcePosition
+                if state.value is not None
+            ],
+            "translation_key": "cover_actuator",
+        },
+    },
+    "SelectSwitchActuatorForcedPosition": {
+        "device_class": SwitchActuator,
+        "current_option_attribute": "forced",
+        "select_option_method": "set_forced",
+        "entity_description_kwargs": {
+            "options": [
+                state.name
+                for state in SwitchActuatorForceState
+                if state.value is not None
+            ],
+            "translation_key": "switch_actuator",
+        },
+    },
+    "SelectDimmingActuatorForcedPosition": {
+        "device_class": DimmingActuator,
+        "current_option_attribute": "forced",
+        "select_option_method": "set_forced",
+        "entity_description_kwargs": {
+            "options": [
+                state.name
+                for state in DimmingActuatorForceState
+                if state.value is not None
+            ],
+            "translation_key": "dimming_actuator",
+        },
+    },
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up switches."""
+    free_at_home: FreeAtHome = hass.data[DOMAIN][entry.entry_id]
+
+    for key, description in SELECT_DESCRIPTIONS.items():
+        async_add_entities(
+            FreeAtHomeSelectEntity(
+                device,
+                entity_description_kwargs={"key": key}
+                | description.get("entity_description_kwargs"),
+                current_option_attribute=description.get("current_option_attribute"),
+                select_option_method=description.get("select_option_method"),
+                sysap_serial_number=entry.data[CONF_SERIAL],
+            )
+            for device in free_at_home.get_devices_by_class(
+                device_class=description.get("device_class")
+            )
+        )
+
+
+class FreeAtHomeSelectEntity(SelectEntity):
+    """Defines a free@home switch entity."""
+
+    _attr_should_poll: bool = False
+
+    def __init__(
+        self,
+        device: SwitchActuator,
+        entity_description_kwargs: dict[str:Any],
+        current_option_attribute: str,
+        select_option_method: str,
+        sysap_serial_number: str,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__()
+        self._device = device
+        self._current_option_attribute = current_option_attribute
+        self._select_option_method = select_option_method
+        self._sysap_serial_number = sysap_serial_number
+
+        self.entity_description = SelectEntityDescription(
+            has_entity_name=True,
+            name=device.channel_name,
+            translation_placeholders={"channel_id": device.channel_id},
+            **entity_description_kwargs,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Run when this Entity has been added to HA."""
+        self._device.register_callback(self.async_write_ha_state)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Entity being removed from hass."""
+        self._device.remove_callback(self.async_write_ha_state)
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._device.avaiable if hasattr(self._device, "available") else True
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Information about this entity/device."""
+        return {
+            "identifiers": {(DOMAIN, self._device.device_id)},
+            "name": self._device.device_name,
+            "manufacturer": "ABB busch-jaeger",
+            "serial_number": self._device.device_id,
+            "suggested_area": self._device.room_name,
+            "via_device": (DOMAIN, self._sysap_serial_number),
+        }
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected entity option to represent the entity state."""
+        return getattr(self._device, self._current_option_attribute)
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return a unique ID."""
+        return f"{self._device.device_id}_{self._device.channel_id}_select"
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await getattr(self._device, self._select_option_method)(option)

--- a/custom_components/abbfreeathome_ci/select.py
+++ b/custom_components/abbfreeathome_ci/select.py
@@ -161,7 +161,10 @@ class FreeAtHomeSelectEntity(SelectEntity):
         self.entity_description = SelectEntityDescription(
             has_entity_name=True,
             name=device.channel_name,
-            translation_placeholders={"channel_id": device.channel_id},
+            translation_placeholders={
+                "channel_id": device.channel_id,
+                "channel_name": device.channel_name,
+            },
             **entity_description_kwargs,
         )
 

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -139,7 +139,7 @@
     },
     "select": {
       "cover_actuator": {
-        "name": "Forced Position",
+        "name": "{channel_name} Forced Position",
         "state": {
           "deactivated": "Deactivated",
           "forced_open": "[%key:common::state::open%]",
@@ -147,7 +147,7 @@
         }
       },
       "dimming_actuator": {
-        "name": "Forced Position",
+        "name": "{channel_name} Forced Position",
         "state": {
           "deactivated": "Deactivated",
           "forced_on": "[%key:common::state::on%]",
@@ -155,7 +155,7 @@
         }
       },
       "switch_actuator": {
-        "name": "Forced Position",
+        "name": "{channel_name} Forced Position",
         "state": {
           "deactivated": "Deactivated",
           "forced_on": "[%key:common::state::on%]",

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -142,8 +142,8 @@
         "name": "Forced Position",
         "state": {
           "deactivated": "Deactivated",
-          "forced_on": "[%key:common::state::open%]",
-          "forced_off": "[%key:common::state::closed%]"
+          "forced_open": "[%key:common::state::open%]",
+          "forced_closed": "[%key:common::state::closed%]"
         }
       },
       "dimming_actuator": {

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -137,6 +137,32 @@
         }
       }
     },
+    "select": {
+      "cover_actuator": {
+        "name": "Forced Position",
+        "state": {
+          "deactivated": "Deactivated",
+          "forced_on": "[%key:common::state::open%]",
+          "forced_off": "[%key:common::state::closed%]"
+        }
+      },
+      "dimming_actuator": {
+        "name": "Forced Position",
+        "state": {
+          "deactivated": "Deactivated",
+          "forced_on": "[%key:common::state::on%]",
+          "forced_off": "[%key:common::state::off%]"
+        }
+      },
+      "switch_actuator": {
+        "name": "Forced Position",
+        "state": {
+          "deactivated": "Deactivated",
+          "forced_on": "[%key:common::state::on%]",
+          "forced_off": "[%key:common::state::off%]"
+        }
+      }
+    },
     "sensor": {
       "brightness_sensor": {
         "name": "Illuminance"

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -137,6 +137,32 @@
         }
       }
     },
+    "select": {
+      "cover_actuator": {
+        "name": "Forced Position",
+        "state": {
+          "deactivated": "Deactivated",
+          "forced_off": "Closed",
+          "forced_on": "Open"
+        }
+      },
+      "dimming_actuator": {
+        "name": "Forced Position",
+        "state": {
+          "deactivated": "Deactivated",
+          "forced_off": "Off",
+          "forced_on": "On"
+        }
+      },
+      "switch_actuator": {
+        "name": "Forced Position",
+        "state": {
+          "deactivated": "Deactivated",
+          "forced_off": "Off",
+          "forced_on": "On"
+        }
+      }
+    },
     "sensor": {
       "brightness_sensor": {
         "name": "Illuminance"

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -139,7 +139,7 @@
     },
     "select": {
       "cover_actuator": {
-        "name": "Forced Position",
+        "name": "{channel_name} Forced Position",
         "state": {
           "deactivated": "Deactivated",
           "forced_closed": "Closed",
@@ -147,7 +147,7 @@
         }
       },
       "dimming_actuator": {
-        "name": "Forced Position",
+        "name": "{channel_name} Forced Position",
         "state": {
           "deactivated": "Deactivated",
           "forced_off": "Off",
@@ -155,7 +155,7 @@
         }
       },
       "switch_actuator": {
-        "name": "Forced Position",
+        "name": "{channel_name} Forced Position",
         "state": {
           "deactivated": "Deactivated",
           "forced_off": "Off",

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -142,8 +142,8 @@
         "name": "Forced Position",
         "state": {
           "deactivated": "Deactivated",
-          "forced_off": "Closed",
-          "forced_on": "Open"
+          "forced_closed": "Closed",
+          "forced_open": "Open"
         }
       },
       "dimming_actuator": {


### PR DESCRIPTION
Closes #78 

This adds the new platform `select` with the forced positions for SwitchActuator, CoverActuator, and DimmingActuator.

Some work on the python package side will still need to be required before this can be merged in, marking this as a draft for now.

I've kept an option to set `available` property up to the Python package, fyi @derjoerg, if the python package implements `available` then it'll be inherited by Home Assistant entities.