### PR TITLE
Ensure has_entity_name is true everywhere

### DIFF
--- a/custom_components/abbfreeathome_ci/button.py
+++ b/custom_components/abbfreeathome_ci/button.py
@@ -38,6 +38,7 @@ class FreeAtHomeButtonEntity(ButtonEntity):
         self._sysap_serial_number = sysap_serial_number
 
         self.entity_description = ButtonEntityDescription(
+            has_entity_name=True,
             key="button",
             name=button.channel_name,
         )

--- a/custom_components/abbfreeathome_ci/climate.py
+++ b/custom_components/abbfreeathome_ci/climate.py
@@ -50,6 +50,7 @@ class FreeAtHomeClimateEntity(ClimateEntity):
         self._sysap_serial_number = sysap_serial_number
 
         self.entity_description = ClimateEntityDescription(
+            has_entity_name=True,
             key="RoomTemperatureController",
             name=climate.channel_name,
         )

--- a/custom_components/abbfreeathome_ci/event.py
+++ b/custom_components/abbfreeathome_ci/event.py
@@ -108,8 +108,6 @@ async def async_setup_entry(
 class FreeAtHomeEventEntity(EventEntity):
     """free@home Event Entity."""
 
-    _attr_has_entity_name: bool = True
-
     def __init__(
         self,
         device: SwitchSensor,
@@ -124,6 +122,7 @@ class FreeAtHomeEventEntity(EventEntity):
         self._event_type_callback = event_type_callback
 
         self.entity_description = EventEntityDescription(
+            has_entity_name=True,
             name=device.channel_name,
             translation_placeholders={"channel_id": device.channel_id},
             **entity_description_kwargs,

--- a/custom_components/abbfreeathome_ci/light.py
+++ b/custom_components/abbfreeathome_ci/light.py
@@ -48,6 +48,7 @@ class FreeAtHomeLightEntity(LightEntity):
         self._sysap_serial_number = sysap_serial_number
 
         self.entity_description = LightEntityDescription(
+            has_entity_name=True,
             key="light",
             name=light.channel_name,
         )

--- a/custom_components/abbfreeathome_ci/lock.py
+++ b/custom_components/abbfreeathome_ci/lock.py
@@ -42,6 +42,7 @@ class FreeAtHomeLockEntity(LockEntity):
         self._sysap_serial_number = sysap_serial_number
 
         self.entity_description = LockEntityDescription(
+            has_entity_name=True,
             key="DesDoorOpenerActuatorLock",
             name=lock.channel_name,
         )

--- a/custom_components/abbfreeathome_ci/sensor.py
+++ b/custom_components/abbfreeathome_ci/sensor.py
@@ -118,7 +118,6 @@ class FreeAtHomeSensorEntity(SensorEntity):
     """Defines a free@home sensor entity."""
 
     _attr_should_poll: bool = False
-    _attr_has_entity_name: bool = True
 
     def __init__(
         self,
@@ -134,6 +133,7 @@ class FreeAtHomeSensorEntity(SensorEntity):
         self._sysap_serial_number = sysap_serial_number
 
         self.entity_description = SensorEntityDescription(
+            has_entity_name=True,
             name=device.channel_name,
             translation_placeholders={"channel_id": device.channel_id},
             **entity_description_kwargs,

--- a/custom_components/abbfreeathome_ci/switch.py
+++ b/custom_components/abbfreeathome_ci/switch.py
@@ -44,6 +44,7 @@ class FreeAtHomeSwitchEntity(SwitchEntity):
         self._sysap_serial_number = sysap_serial_number
 
         self.entity_description = SwitchEntityDescription(
+            has_entity_name=True,
             key="switch",
             device_class=SwitchDeviceClass.SWITCH,
             name=switch.channel_name,

--- a/custom_components/abbfreeathome_ci/valve.py
+++ b/custom_components/abbfreeathome_ci/valve.py
@@ -45,6 +45,7 @@ class FreeAtHomeValveEntity(ValveEntity):
         self._sysap_serial_number = sysap_serial_number
 
         self.entity_description = ValveEntityDescription(
+            has_entity_name=True,
             key="HeatingActuatorValve",
             device_class=ValveDeviceClass.WATER,
             entity_registry_enabled_default=False,


### PR DESCRIPTION
The attribute `has_entity_name` must be true for all new integrations. See: https://developers.home-assistant.io/docs/core/entity#has_entity_name-true-mandatory-for-new-integrations

This PR ensure's all platforms have this set to True (it's false by default). And that it's set in the entity description and not at the class level.

For binary sensor instead of removing `translation_key` from the entity_description in the entity constructor, I'm overriding the parent entity `translation_key` property. This is how it should properly be done