### PR TITLE
Revert has_entity_name=True

### DIFF
--- a/custom_components/abbfreeathome_ci/button.py
+++ b/custom_components/abbfreeathome_ci/button.py
@@ -38,7 +38,6 @@ class FreeAtHomeButtonEntity(ButtonEntity):
         self._sysap_serial_number = sysap_serial_number
 
         self.entity_description = ButtonEntityDescription(
-            has_entity_name=True,
             key="button",
             name=button.channel_name,
         )

--- a/custom_components/abbfreeathome_ci/climate.py
+++ b/custom_components/abbfreeathome_ci/climate.py
@@ -50,7 +50,6 @@ class FreeAtHomeClimateEntity(ClimateEntity):
         self._sysap_serial_number = sysap_serial_number
 
         self.entity_description = ClimateEntityDescription(
-            has_entity_name=True,
             key="RoomTemperatureController",
             name=climate.channel_name,
         )

--- a/custom_components/abbfreeathome_ci/light.py
+++ b/custom_components/abbfreeathome_ci/light.py
@@ -48,7 +48,6 @@ class FreeAtHomeLightEntity(LightEntity):
         self._sysap_serial_number = sysap_serial_number
 
         self.entity_description = LightEntityDescription(
-            has_entity_name=True,
             key="light",
             name=light.channel_name,
         )

--- a/custom_components/abbfreeathome_ci/lock.py
+++ b/custom_components/abbfreeathome_ci/lock.py
@@ -42,7 +42,6 @@ class FreeAtHomeLockEntity(LockEntity):
         self._sysap_serial_number = sysap_serial_number
 
         self.entity_description = LockEntityDescription(
-            has_entity_name=True,
             key="DesDoorOpenerActuatorLock",
             name=lock.channel_name,
         )

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "requirements": ["local-abbfreeathome==1.15.1"],
   "ssdp": [],
-  "version": "0.14.0",
+  "version": "0.14.1",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/custom_components/abbfreeathome_ci/switch.py
+++ b/custom_components/abbfreeathome_ci/switch.py
@@ -44,7 +44,6 @@ class FreeAtHomeSwitchEntity(SwitchEntity):
         self._sysap_serial_number = sysap_serial_number
 
         self.entity_description = SwitchEntityDescription(
-            has_entity_name=True,
             key="switch",
             device_class=SwitchDeviceClass.SWITCH,
             name=switch.channel_name,

--- a/custom_components/abbfreeathome_ci/valve.py
+++ b/custom_components/abbfreeathome_ci/valve.py
@@ -45,7 +45,6 @@ class FreeAtHomeValveEntity(ValveEntity):
         self._sysap_serial_number = sysap_serial_number
 
         self.entity_description = ValveEntityDescription(
-            has_entity_name=True,
             key="HeatingActuatorValve",
             device_class=ValveDeviceClass.WATER,
             entity_registry_enabled_default=False,


### PR DESCRIPTION
Setting the has_entity_name has some adverse affects with how free@home device > channel relationships are.

Even though it's required by Home Assistant, it does say

> The entity's name property only identifies the data point represented by the entity, and should not include the name of the device or the type of the entity. So for a sensor that represents the power usage of its device, this would be “Power usage”.

This means that setting the entity name to the free@home channel_name is also not the correct use. And you end up with long entity names and id's that'll most certainly have to be adjusted by the user.

But leaving the entity name out would then use the device name, which may or may not be helpful based on how the user has setup free@home, and in those cases where a device have multiple primary functions (e.g. double switch) you end up with two entities with the same exact name.

Hopefully, because of this use-case HA is ok with this. For this integration the rule should be:

> If the channel is the primary channel of the device then has_entity_name should be False and the entity name will come from the channel name (e.g. Living Room Light Switch). If the channel is NOT the primary channel of the device then the entity name should be it's function and be translated (e.g. Illuminance).

<img width="585" alt="image" src="https://github.com/user-attachments/assets/9daa49e9-e0a9-4691-b1a2-0f5919fd91b8">
<img width="445" alt="Screenshot 2024-11-17 at 10 59 39" src="https://github.com/user-attachments/assets/47b65eb7-c64a-45a0-b874-855f2bc18af6">
