### PR TITLE
Add PyPi packages to loggers manifest

### DIFF
--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -7,6 +7,7 @@
   "documentation": "https://github.com/kingsleyadam/local-abbfreeathome-hass",
   "homekit": {},
   "iot_class": "local_push",
+  "loggers": ["abbfreeathome"],
   "requirements": ["local-abbfreeathome==1.16.1"],
   "ssdp": [],
   "version": "0.14.1",


### PR DESCRIPTION
With this added, when debug logging is enabled on the integration it'll include debug logs from both the integration and the PyPi package.