### PR TITLE
Use the FreeAtHomeSettings class to check SysAP compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,17 @@ The current list of supported devices by function are:
 | FID_DIMMING_SENSOR                                 | `Event`                   |
 | FID_FORCE_ON_OFF_SENSOR                            | `Event`                   |
 | FID_HEATING_ACTUATOR                               | `Valve`                   |
+| FID_MOVEMENT_DETECTOR                              | `Binary Sensor`, `Sensor` |
+| FID_MOVEMENT_DETECTOR_PYCUSTOM0                    | `Binary Sensor`, `Sensor` |
 | FID_RAIN_SENSOR                                    | `Binary Sensor`           |
 | FID_ROOM_TEMPERATURE_CONTROLLER_MASTER_WITHOUT_FAN | `Climate`                 |
 | FID_SHUTTER_ACTUATOR                               | `Cover`                   |
 | FID_SMOKE_DETECTOR                                 | `Binary Sensor`           |
 | FID_SWITCH_ACTUATOR                                | `Switch`                  |
+| FID_SWITCH_ACTUATOR_PYCUSTOM0                      | `Switch`                  |
 | FID_SWITCH_SENSOR                                  | `Event`                   |
 | FID_TEMPERATURE_SENSOR                             | `Binary Sensor`, `Sensor` |
 | FID_TRIGGER                                        | `Button`                  |
-| FID_MOVEMENT_DETECTOR                              | `Binary Sensor`, `Sensor` |
 | FID_WIND_SENSOR                                    | `Binary Sensor`, `Sensor` |
 | FID_WINDOW_DOOR_SENSOR                             | `Binary Sensor`           |
 | FID_WINDOW_DOOR_POSITION_SENSOR                    | `Binary Sensor`, `Sensor` |

--- a/custom_components/abbfreeathome_ci/config_flow.py
+++ b/custom_components/abbfreeathome_ci/config_flow.py
@@ -16,7 +16,6 @@ from abbfreeathome.api import (
     InvalidHostException,
 )
 from aiohttp import ClientSession
-from packaging.version import Version
 import voluptuous as vol
 
 from homeassistant.components import zeroconf
@@ -68,7 +67,7 @@ async def validate_settings(
     try:
         await settings.load()
 
-        if Version(settings.version) < Version("2.6.0"):
+        if not settings.has_api_support:
             errors["base"] = "unsupported_sysap_version"
     except InvalidHostException:
         errors["base"] = "cannot_connect"

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -8,9 +8,9 @@
   "homekit": {},
   "iot_class": "local_push",
   "loggers": ["abbfreeathome"],
-  "requirements": ["local-abbfreeathome==1.16.2"],
+  "requirements": ["local-abbfreeathome==1.17.0"],
   "ssdp": [],
-  "version": "0.15.1",
+  "version": "0.16.0",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",


### PR DESCRIPTION
This moves the check on whether the SysAP has api support to the Python package which added a check in https://github.com/kingsleyadam/local-abbfreeathome/pull/131.

Also adds support for two additional functions added in https://github.com/kingsleyadam/local-abbfreeathome/pull/130

