### PR TITLE
Convert dimmer brightness to int before setting

### DIFF
--- a/custom_components/abbfreeathome_ci/light.py
+++ b/custom_components/abbfreeathome_ci/light.py
@@ -101,7 +101,7 @@ class FreeAtHomeLightEntity(LightEntity):
         """Turn the light on."""
         if ATTR_BRIGHTNESS in kwargs:
             await self._light.set_brightness(
-                brightness_to_value(BRIGHTNESS_SCALE, kwargs[ATTR_BRIGHTNESS])
+                int(brightness_to_value(BRIGHTNESS_SCALE, kwargs[ATTR_BRIGHTNESS]))
             )
         else:
             await self._light.turn_on()

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -10,7 +10,7 @@
   "loggers": ["abbfreeathome"],
   "requirements": ["local-abbfreeathome==1.19.0"],
   "ssdp": [],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",


### PR DESCRIPTION
Closes #124 

The ABB SysAP doesn't seem to work with floats very well, so we need to convert the dimmer brightness to an integer before setting it.

I don't have any way to test this, this has only come up on a newly added dimmer actuator type.