### PR TITLE
Bugfix: Add interface `smokealarm` after firmware upgrade to 3.5.0

### DIFF
--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -121,6 +121,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         Interface.UNDEFINED,
         Interface.WIRED_BUS,
         Interface.WIRELESS_RF,
+        Interface.SMOKEALARM,
     ]
 
     # Attempt to fetch virtual devices config entry, if not found fallback to False

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -8,9 +8,9 @@
   "homekit": {},
   "iot_class": "local_push",
   "loggers": ["abbfreeathome"],
-  "requirements": ["local-abbfreeathome==2.1.1"],
+  "requirements": ["local-abbfreeathome==2.1.2"],
   "ssdp": [],
-  "version": "1.4.3",
+  "version": "1.4.4",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",


### PR DESCRIPTION
This depends on the relevant PR of the library