### PR TITLE
Implement possibility to have sub-devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,14 @@ Copy the username listed within that window (usually `installer`) to be used whe
 
 The config setup will include some options to help configure the integration.
 
-| Configuration                                    | Description                                                                                                        |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
-| Hostname                                         | **Only available in Manual (User) Setup.** The full hostname including schema of the ABB-free@home SysAP endpoint. |
-| Username                                         | The **api** username, likely different from your normal login username.                                            |
-| Password                                         | The password for logging into the SysAP.                                                                           |
-| Include channels NOT on the free@home floorplan? | Whether to include channels that are not located on the free@home floorplan.                                       |
-| Include virtual devices?                         | Whether to include virtual devices or not.                                                                         |
+| Configuration                                    | Description                                                                                                                              |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Hostname                                         | **Only available in Manual (User) Setup.** The full hostname including schema of the ABB-free@home SysAP endpoint.                       |
+| Username                                         | The **api** username, likely different from your normal login username.                                                                  |
+| Password                                         | The password for logging into the SysAP.                                                                                                 |
+| Include channels NOT on the free@home floorplan? | Whether to include channels that are not located on the free@home floorplan.                                                             |
+| Include virtual devices?                         | Whether to include virtual devices or not.                                                                                               |
+| Create Sub-Devices for each independent channel? | Wether to create sub-devices for each channel of a physical device, which can be placed independently on the free@home floorplan or not. |
 
 ###### Example
 
@@ -107,6 +108,7 @@ The config setup will include some options to help configure the integration.
 - **Password**: `<password>`
 - **Include channels NOT on the free@home floorplan?**: False
 - **Include virtual devices?**: False
+- **Create Sub-Devices for each independent channel?**: False
 
 > Note: Support for SSL is not provided yet. For a valid SSL connection a cert pulled from the SysAP must be provided, research to be done to know if Home Assistant supports such a scenario.
 
@@ -131,6 +133,7 @@ abbfreeathome_ci:
   password: <password>
   include_orphan_channels: false
   include_virtual_devices: false
+  include_subdevices: false
 ```
 
 Each time Home Assistant is loaded, the `configuration.yaml` entry for `abbfreeathome_ci` will be checked, verified, and updated accordingly. This means that if you want to update your configuration, simply modify the `configuration.yaml` file and restart Home Assistant.
@@ -166,14 +169,14 @@ triggers:
   - trigger: state
     entity_id:
       - event.study_area_rocker_switch_event
-    to: 'Off'
+    to: "Off"
     attribute: event_type
     id: study_area_event_off
   - trigger: state
     entity_id:
       - event.study_area_rocker_switch_event
     attribute: event_type
-    to: 'On'
+    to: "On"
     id: study_area_event_on
 conditions: []
 actions:

--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -29,6 +29,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
+    CONF_CREATE_SUBDEVICES,
     CONF_INCLUDE_ORPHAN_CHANNELS,
     CONF_INCLUDE_VIRTUAL_DEVICES,
     CONF_SERIAL,
@@ -72,6 +73,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Required(CONF_PASSWORD): cv.string,
                 vol.Optional(CONF_INCLUDE_ORPHAN_CHANNELS, default=False): cv.boolean,
                 vol.Optional(CONF_INCLUDE_VIRTUAL_DEVICES, default=False): cv.boolean,
+                vol.Optional(CONF_CREATE_SUBDEVICES, default=False): cv.boolean,
             }
         )
     },
@@ -237,6 +239,13 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         hass.config_entries.async_update_entry(
             entry, data=new_data, version=1, minor_version=3
+        )
+
+        if entry.minor_version < 4:
+            new_data[CONF_CREATE_SUBDEVICES] = False
+
+        hass.config_entries.async_update_entry(
+            entry, data=new_data, version=1, minor_version=4
         )
 
     _LOGGER.debug(

--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -34,6 +34,7 @@ from .const import (
     CONF_INCLUDE_VIRTUAL_DEVICES,
     CONF_SERIAL,
     DOMAIN,
+    MANUFACTURER,
     VIRTUAL_DEVICE,
 )
 
@@ -157,7 +158,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.data[CONF_SERIAL])},
-        manufacturer="ABB Busch-Jaeger",
+        manufacturer=MANUFACTURER,
         model="System Access Point",
         name=_free_at_home_settings.name,
         serial_number=entry.data[CONF_SERIAL],
@@ -167,21 +168,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     for _device in _free_at_home.get_devices().values():
-        # Skip special F@H devices
-        if (
-            _device.device_serial.startswith("FFFF")  # Scenes
-            or _device.device_id
-            == "FFFF"  # System Access Point with a serial of "ABB700000000"
-            or not _device.channels  # No channels available
-        ):
+        if not _free_at_home.get_channels_by_device(_device.device_serial):
             continue
 
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={(DOMAIN, _device.device_serial)},
             name=_device.display_name,
-            manufacturer="ABB Busch-Jaeger",
+            manufacturer=MANUFACTURER,
             serial_number=_device.device_serial,
+            hw_version=_device.device_id,
             suggested_area=_device.room_name,
             via_device=(DOMAIN, entry.data[CONF_SERIAL]),
         )

--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -166,6 +166,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         configuration_url=entry.data[CONF_HOST],
     )
 
+    # Check, if sub-devices for multi-devices should be created
+    if entry.data[CONF_CREATE_SUBDEVICES]:
+        for _device in _free_at_home.get_devices().values():
+            if _device.is_multi_device:
+                device_registry.async_get_or_create(
+                    config_entry_id=entry.entry_id,
+                    identifiers={(DOMAIN, _device.device_serial)},
+                    name=_device.display_name,
+                    manufacturer="ABB Busch-Jaeger",
+                    serial_number=_device.device_serial,
+                    suggested_area=None,
+                    via_device=(DOMAIN, entry.data[CONF_SERIAL]),
+                )
+
     # Add the FreeAtHome object to hass data
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _free_at_home
 

--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -170,8 +170,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Skip special F@H devices
         if (
             _device.device_serial.startswith("FFFF")  # Scenes
-            or _device.device_id == "FFFF"  # System Access Point
-            or len(_device.channels.keys()) == 0
+            or _device.device_id
+            == "FFFF"  # System Access Point with a serial of "ABB700000000"
+            or not _device.channels  # No channels available
         ):
             continue
 

--- a/custom_components/abbfreeathome_ci/binary_sensor.py
+++ b/custom_components/abbfreeathome_ci/binary_sensor.py
@@ -19,10 +19,11 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
 
 SENSOR_DESCRIPTIONS = {
     "CarbonMonoxideSensorOnOff": {
@@ -108,6 +109,9 @@ async def async_setup_entry(
                 entity_description_kwargs={"key": key}
                 | description.get("entity_description_kwargs"),
                 sysap_serial_number=entry.data[CONF_SERIAL],
+                hass=hass,
+                create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
+                config_entry_id=entry.entry_id,
             )
             for channel in free_at_home.get_channels_by_class(
                 channel_class=description.get("channel_class")
@@ -134,12 +138,16 @@ class FreeAtHomeBinarySensorEntity(BinarySensorEntity):
         value_attribute: str,
         entity_description_kwargs: dict[str:Any],
         sysap_serial_number: str,
+        hass: HomeAssistant,
+        create_subdevices: bool,
+        config_entry_id: str,
     ) -> None:
         """Initialize the sensor."""
         super().__init__()
         self._channel = channel
         self._value_attribute = value_attribute
         self._sysap_serial_number = sysap_serial_number
+        self._create_subdevices = create_subdevices
 
         self.entity_description = BinarySensorEntityDescription(
             has_entity_name=True,
@@ -147,6 +155,18 @@ class FreeAtHomeBinarySensorEntity(BinarySensorEntity):
             translation_placeholders={"channel_id": channel.channel_id},
             **entity_description_kwargs,
         )
+
+        if self._create_subdevices and self._channel.device.floor is None:
+            device_registry = dr.async_get(hass)
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry_id,
+                identifiers={(DOMAIN, self._channel.device_serial)},
+                name=self._channel.device_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=self._channel.device_serial,
+                suggested_area=None,
+                via_device=(DOMAIN, self._sysap_serial_number),
+            )
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
@@ -163,12 +183,27 @@ class FreeAtHomeBinarySensorEntity(BinarySensorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
+        if self._create_subdevices and self._channel.device.floor is None:
+            return {
+                "identifiers": {
+                    (
+                        DOMAIN,
+                        f"{self._channel.device_serial}_{self._channel.channel_id}",
+                    )
+                },
+                "name": self._channel.channel_name,
+                "manufacturer": "ABB Busch-Jaeger",
+                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
+                "suggested_area": self._channel.room_name,
+                "via_device": (DOMAIN, self._channel.device_serial),
+            }
+
         return {
             "identifiers": {(DOMAIN, self._channel.device_serial)},
             "name": self._channel.device_name,
-            "manufacturer": "ABB busch-jaeger",
+            "manufacturer": "ABB Busch-Jaeger",
             "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.room_name,
+            "suggested_area": self._channel.device.room_name,
             "via_device": (DOMAIN, self._sysap_serial_number),
         }
 

--- a/custom_components/abbfreeathome_ci/binary_sensor.py
+++ b/custom_components/abbfreeathome_ci/binary_sensor.py
@@ -19,7 +19,6 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -109,9 +108,7 @@ async def async_setup_entry(
                 entity_description_kwargs={"key": key}
                 | description.get("entity_description_kwargs"),
                 sysap_serial_number=entry.data[CONF_SERIAL],
-                hass=hass,
                 create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
-                config_entry_id=entry.entry_id,
             )
             for channel in free_at_home.get_channels_by_class(
                 channel_class=description.get("channel_class")
@@ -138,9 +135,7 @@ class FreeAtHomeBinarySensorEntity(BinarySensorEntity):
         value_attribute: str,
         entity_description_kwargs: dict[str:Any],
         sysap_serial_number: str,
-        hass: HomeAssistant,
         create_subdevices: bool,
-        config_entry_id: str,
     ) -> None:
         """Initialize the sensor."""
         super().__init__()
@@ -155,18 +150,6 @@ class FreeAtHomeBinarySensorEntity(BinarySensorEntity):
             translation_placeholders={"channel_id": channel.channel_id},
             **entity_description_kwargs,
         )
-
-        if self._create_subdevices and self._channel.device.floor is None:
-            device_registry = dr.async_get(hass)
-            device_registry.async_get_or_create(
-                config_entry_id=config_entry_id,
-                identifiers={(DOMAIN, self._channel.device_serial)},
-                name=self._channel.device_name,
-                manufacturer="ABB Busch-Jaeger",
-                serial_number=self._channel.device_serial,
-                suggested_area=None,
-                via_device=(DOMAIN, self._sysap_serial_number),
-            )
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
@@ -183,7 +166,7 @@ class FreeAtHomeBinarySensorEntity(BinarySensorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
-        if self._create_subdevices and self._channel.device.floor is None:
+        if self._create_subdevices and self._channel.device.is_multi_device:
             return {
                 "identifiers": {
                     (

--- a/custom_components/abbfreeathome_ci/binary_sensor.py
+++ b/custom_components/abbfreeathome_ci/binary_sensor.py
@@ -167,28 +167,21 @@ class FreeAtHomeBinarySensorEntity(BinarySensorEntity):
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
         if self._create_subdevices and self._channel.device.is_multi_device:
-            return {
-                "identifiers": {
+            return DeviceInfo(
+                identifiers={
                     (
                         DOMAIN,
                         f"{self._channel.device_serial}_{self._channel.channel_id}",
                     )
                 },
-                "name": self._channel.channel_name,
-                "manufacturer": "ABB Busch-Jaeger",
-                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
-                "suggested_area": self._channel.room_name,
-                "via_device": (DOMAIN, self._channel.device_serial),
-            }
+                name=self._channel.channel_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                suggested_area=self._channel.room_name,
+                via_device=(DOMAIN, self._channel.device_serial),
+            )
 
-        return {
-            "identifiers": {(DOMAIN, self._channel.device_serial)},
-            "name": self._channel.device_name,
-            "manufacturer": "ABB Busch-Jaeger",
-            "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.device.room_name,
-            "via_device": (DOMAIN, self._sysap_serial_number),
-        }
+        return DeviceInfo(identifiers={(DOMAIN, self._channel.device_serial)})
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/abbfreeathome_ci/binary_sensor.py
+++ b/custom_components/abbfreeathome_ci/binary_sensor.py
@@ -22,7 +22,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN, MANUFACTURER
 
 SENSOR_DESCRIPTIONS = {
     "CarbonMonoxideSensorOnOff": {
@@ -175,8 +175,9 @@ class FreeAtHomeBinarySensorEntity(BinarySensorEntity):
                     )
                 },
                 name=self._channel.channel_name,
-                manufacturer="ABB Busch-Jaeger",
+                manufacturer=MANUFACTURER,
                 serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                hw_version=f"{self._channel.device.device_id} (sub)",
                 suggested_area=self._channel.room_name,
                 via_device=(DOMAIN, self._channel.device_serial),
             )

--- a/custom_components/abbfreeathome_ci/button.py
+++ b/custom_components/abbfreeathome_ci/button.py
@@ -6,10 +6,11 @@ from abbfreeathome.channels.trigger import Trigger
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
 
 
 async def async_setup_entry(
@@ -21,8 +22,14 @@ async def async_setup_entry(
     free_at_home: FreeAtHome = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities(
-        FreeAtHomeButtonEntity(button, sysap_serial_number=entry.data[CONF_SERIAL])
-        for button in free_at_home.get_channels_by_class(channel_class=Trigger)
+        FreeAtHomeButtonEntity(
+            channel,
+            sysap_serial_number=entry.data[CONF_SERIAL],
+            hass=hass,
+            create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
+            config_entry_id=entry.entry_id,
+        )
+        for channel in free_at_home.get_channels_by_class(channel_class=Trigger)
     )
 
 
@@ -31,34 +38,69 @@ class FreeAtHomeButtonEntity(ButtonEntity):
 
     _attr_should_poll: bool = False
 
-    def __init__(self, button: Trigger, sysap_serial_number: str) -> None:
+    def __init__(
+        self,
+        channel: Trigger,
+        sysap_serial_number: str,
+        hass: HomeAssistant,
+        create_subdevices: bool,
+        config_entry_id: str,
+    ) -> None:
         """Initialize the button."""
         super().__init__()
-        self._button = button
+        self._channel = channel
         self._sysap_serial_number = sysap_serial_number
+        self._create_subdevices = create_subdevices
 
         self.entity_description = ButtonEntityDescription(
             key="button",
-            name=button.channel_name,
+            name=channel.channel_name,
         )
+
+        if self._create_subdevices and self._channel.device.floor is None:
+            device_registry = dr.async_get(hass)
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry_id,
+                identifiers={(DOMAIN, self._channel.device_serial)},
+                name=self._channel.device_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=self._channel.device_serial,
+                suggested_area=None,
+                via_device=(DOMAIN, self._sysap_serial_number),
+            )
 
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
+        if self._create_subdevices and self._channel.device.floor is None:
+            return {
+                "identifiers": {
+                    (
+                        DOMAIN,
+                        f"{self._channel.device_serial}_{self._channel.channel_id}",
+                    )
+                },
+                "name": self._channel.channel_name,
+                "manufacturer": "ABB Busch-Jaeger",
+                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
+                "suggested_area": self._channel.room_name,
+                "via_device": (DOMAIN, self._channel.device_serial),
+            }
+
         return {
-            "identifiers": {(DOMAIN, self._button.device_serial)},
-            "name": self._button.device_name,
-            "manufacturer": "ABB busch-jaeger",
-            "serial_number": self._button.device_serial,
-            "suggested_area": self._button.room_name,
+            "identifiers": {(DOMAIN, self._channel.device_serial)},
+            "name": self._channel.device_name,
+            "manufacturer": "ABB Busch-Jaeger",
+            "serial_number": self._channel.device_serial,
+            "suggested_area": self._channel.device.room_name,
             "via_device": (DOMAIN, self._sysap_serial_number),
         }
 
     @property
     def unique_id(self) -> str | None:
         """Return a unique ID."""
-        return f"{self._button.device_serial}_{self._button.channel_id}_button"
+        return f"{self._channel.device_serial}_{self._channel.channel_id}_button"
 
     async def async_press(self) -> None:
         """Press the button."""
-        await self._button.press()
+        await self._channel.press()

--- a/custom_components/abbfreeathome_ci/button.py
+++ b/custom_components/abbfreeathome_ci/button.py
@@ -56,28 +56,21 @@ class FreeAtHomeButtonEntity(ButtonEntity):
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
         if self._create_subdevices and self._channel.device.is_multi_device:
-            return {
-                "identifiers": {
+            return DeviceInfo(
+                identifiers={
                     (
                         DOMAIN,
                         f"{self._channel.device_serial}_{self._channel.channel_id}",
                     )
                 },
-                "name": self._channel.channel_name,
-                "manufacturer": "ABB Busch-Jaeger",
-                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
-                "suggested_area": self._channel.room_name,
-                "via_device": (DOMAIN, self._channel.device_serial),
-            }
+                name=self._channel.channel_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                suggested_area=self._channel.room_name,
+                via_device=(DOMAIN, self._channel.device_serial),
+            )
 
-        return {
-            "identifiers": {(DOMAIN, self._channel.device_serial)},
-            "name": self._channel.device_name,
-            "manufacturer": "ABB Busch-Jaeger",
-            "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.device.room_name,
-            "via_device": (DOMAIN, self._sysap_serial_number),
-        }
+        return DeviceInfo(identifiers={(DOMAIN, self._channel.device_serial)})
 
     @property
     def unique_id(self) -> str | None:

--- a/custom_components/abbfreeathome_ci/button.py
+++ b/custom_components/abbfreeathome_ci/button.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN, MANUFACTURER
 
 
 async def async_setup_entry(
@@ -64,8 +64,9 @@ class FreeAtHomeButtonEntity(ButtonEntity):
                     )
                 },
                 name=self._channel.channel_name,
-                manufacturer="ABB Busch-Jaeger",
+                manufacturer=MANUFACTURER,
                 serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                hw_version=f"{self._channel.device.device_id} (sub)",
                 suggested_area=self._channel.room_name,
                 via_device=(DOMAIN, self._channel.device_serial),
             )

--- a/custom_components/abbfreeathome_ci/button.py
+++ b/custom_components/abbfreeathome_ci/button.py
@@ -6,7 +6,6 @@ from abbfreeathome.channels.trigger import Trigger
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -25,9 +24,7 @@ async def async_setup_entry(
         FreeAtHomeButtonEntity(
             channel,
             sysap_serial_number=entry.data[CONF_SERIAL],
-            hass=hass,
             create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
-            config_entry_id=entry.entry_id,
         )
         for channel in free_at_home.get_channels_by_class(channel_class=Trigger)
     )
@@ -42,9 +39,7 @@ class FreeAtHomeButtonEntity(ButtonEntity):
         self,
         channel: Trigger,
         sysap_serial_number: str,
-        hass: HomeAssistant,
         create_subdevices: bool,
-        config_entry_id: str,
     ) -> None:
         """Initialize the button."""
         super().__init__()
@@ -57,22 +52,10 @@ class FreeAtHomeButtonEntity(ButtonEntity):
             name=channel.channel_name,
         )
 
-        if self._create_subdevices and self._channel.device.floor is None:
-            device_registry = dr.async_get(hass)
-            device_registry.async_get_or_create(
-                config_entry_id=config_entry_id,
-                identifiers={(DOMAIN, self._channel.device_serial)},
-                name=self._channel.device_name,
-                manufacturer="ABB Busch-Jaeger",
-                serial_number=self._channel.device_serial,
-                suggested_area=None,
-                via_device=(DOMAIN, self._sysap_serial_number),
-            )
-
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
-        if self._create_subdevices and self._channel.device.floor is None:
+        if self._create_subdevices and self._channel.device.is_multi_device:
             return {
                 "identifiers": {
                     (

--- a/custom_components/abbfreeathome_ci/climate.py
+++ b/custom_components/abbfreeathome_ci/climate.py
@@ -90,28 +90,21 @@ class FreeAtHomeClimateEntity(ClimateEntity):
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
         if self._create_subdevices and self._channel.device.is_multi_device:
-            return {
-                "identifiers": {
+            return DeviceInfo(
+                identifiers={
                     (
                         DOMAIN,
                         f"{self._channel.device_serial}_{self._channel.channel_id}",
                     )
                 },
-                "name": self._channel.channel_name,
-                "manufacturer": "ABB Busch-Jaeger",
-                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
-                "suggested_area": self._channel.room_name,
-                "via_device": (DOMAIN, self._channel.device_serial),
-            }
+                name=self._channel.channel_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                suggested_area=self._channel.room_name,
+                via_device=(DOMAIN, self._channel.device_serial),
+            )
 
-        return {
-            "identifiers": {(DOMAIN, self._channel.device_serial)},
-            "name": self._channel.device_name,
-            "manufacturer": "ABB Busch-Jaeger",
-            "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.device.room_name,
-            "via_device": (DOMAIN, self._sysap_serial_number),
-        }
+        return DeviceInfo(identifiers={(DOMAIN, self._channel.device_serial)})
 
     @property
     def unique_id(self) -> str | None:

--- a/custom_components/abbfreeathome_ci/climate.py
+++ b/custom_components/abbfreeathome_ci/climate.py
@@ -14,10 +14,11 @@ from homeassistant.components.climate.const import HVACAction, HVACMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
 
 
 async def async_setup_entry(
@@ -29,8 +30,14 @@ async def async_setup_entry(
     free_at_home: FreeAtHome = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities(
-        FreeAtHomeClimateEntity(climate, sysap_serial_number=entry.data[CONF_SERIAL])
-        for climate in free_at_home.get_channels_by_class(
+        FreeAtHomeClimateEntity(
+            channel,
+            sysap_serial_number=entry.data[CONF_SERIAL],
+            hass=hass,
+            create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
+            config_entry_id=entry.entry_id,
+        )
+        for channel in free_at_home.get_channels_by_class(
             channel_class=RoomTemperatureController
         )
     )
@@ -50,22 +57,40 @@ class FreeAtHomeClimateEntity(ClimateEntity):
     ]
 
     def __init__(
-        self, climate: RoomTemperatureController, sysap_serial_number: str
+        self,
+        channel: RoomTemperatureController,
+        sysap_serial_number: str,
+        hass: HomeAssistant,
+        create_subdevices: bool,
+        config_entry_id: str,
     ) -> None:
         """Initialize the climate device."""
         super().__init__()
-        self._climate = climate
+        self._channel = channel
         self._sysap_serial_number = sysap_serial_number
+        self._create_subdevices = create_subdevices
 
         self.entity_description = ClimateEntityDescription(
             key="RoomTemperatureController",
-            name=climate.channel_name,
+            name=channel.channel_name,
         )
+
+        if self._create_subdevices and self._channel.device.floor is None:
+            device_registry = dr.async_get(hass)
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry_id,
+                identifiers={(DOMAIN, self._channel.device_serial)},
+                name=self._channel.device_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=self._channel.device_serial,
+                suggested_area=None,
+                via_device=(DOMAIN, self._sysap_serial_number),
+            )
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
         for _callback_attribute in self._callback_attributes:
-            self._climate.register_callback(
+            self._channel.register_callback(
                 callback_attribute=_callback_attribute,
                 callback=self.async_write_ha_state,
             )
@@ -73,7 +98,7 @@ class FreeAtHomeClimateEntity(ClimateEntity):
     async def async_will_remove_from_hass(self) -> None:
         """Entity being removed from hass."""
         for _callback_attribute in self._callback_attributes:
-            self._climate.remove_callback(
+            self._channel.remove_callback(
                 callback_attribute=_callback_attribute,
                 callback=self.async_write_ha_state,
             )
@@ -81,19 +106,34 @@ class FreeAtHomeClimateEntity(ClimateEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
+        if self._create_subdevices and self._channel.device.floor is None:
+            return {
+                "identifiers": {
+                    (
+                        DOMAIN,
+                        f"{self._channel.device_serial}_{self._channel.channel_id}",
+                    )
+                },
+                "name": self._channel.channel_name,
+                "manufacturer": "ABB Busch-Jaeger",
+                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
+                "suggested_area": self._channel.room_name,
+                "via_device": (DOMAIN, self._channel.device_serial),
+            }
+
         return {
-            "identifiers": {(DOMAIN, self._climate.device_serial)},
-            "name": self._climate.device_name,
-            "manufacturer": "ABB busch-jaeger",
-            "serial_number": self._climate.device_serial,
-            "suggested_area": self._climate.room_name,
+            "identifiers": {(DOMAIN, self._channel.device_serial)},
+            "name": self._channel.device_name,
+            "manufacturer": "ABB Busch-Jaeger",
+            "serial_number": self._channel.device_serial,
+            "suggested_area": self._channel.device.room_name,
             "via_device": (DOMAIN, self._sysap_serial_number),
         }
 
     @property
     def unique_id(self) -> str | None:
         """Return a unique ID."""
-        return f"{self._climate.device_serial}_{self._climate.channel_id}_climate"
+        return f"{self._channel.device_serial}_{self._channel.channel_id}_climate"
 
     @property
     def temperature_unit(self) -> str | None:
@@ -118,17 +158,17 @@ class FreeAtHomeClimateEntity(ClimateEntity):
     @property
     def extra_state_attributes(self) -> dict[Any] | None:
         """Return device specific state attributes."""
-        return {"heating": self._climate.heating, "cooling": self._climate.cooling}
+        return {"heating": self._channel.heating, "cooling": self._channel.cooling}
 
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        return self._climate.current_temperature
+        return self._channel.current_temperature
 
     @property
     def hvac_mode(self) -> HVACMode | None:
         """Return the current mode."""
-        if not self._climate.state:
+        if not self._channel.state:
             return HVACMode.OFF
         return HVACMode.HEAT_COOL
 
@@ -138,9 +178,9 @@ class FreeAtHomeClimateEntity(ClimateEntity):
         if self.hvac_mode == HVACMode.OFF:
             return HVACAction.OFF
 
-        if self._climate.heating > self._climate.cooling:
+        if self._channel.heating > self._channel.cooling:
             return HVACAction.HEATING
-        if self._climate.cooling > self._climate.heating:
+        if self._channel.cooling > self._channel.heating:
             return HVACAction.COOLING
 
         return HVACAction.IDLE
@@ -150,7 +190,7 @@ class FreeAtHomeClimateEntity(ClimateEntity):
         """Return the target temperature."""
         if self.hvac_mode == HVACMode.OFF:
             return None
-        return self._climate.target_temperature
+        return self._channel.target_temperature
 
     @property
     def supported_features(self) -> int | None:
@@ -175,45 +215,45 @@ class FreeAtHomeClimateEntity(ClimateEntity):
     @property
     def preset_mode(self) -> str | None:
         """Return the current mode."""
-        if self._climate.eco_mode:
+        if self._channel.eco_mode:
             return "eco"
         return None
 
     @property
     def state(self) -> bool | None:
         """Return the current operation."""
-        if not self._climate.state:
+        if not self._channel.state:
             return HVACMode.OFF
         return HVACMode.HEAT_COOL
 
     async def async_set_hvac_mode(self, hvac_mode) -> None:
         """Set new target operation mode."""
         if hvac_mode == HVACMode.HEAT_COOL:
-            await self._climate.turn_on()
+            await self._channel.turn_on()
 
         if hvac_mode == HVACMode.OFF:
-            await self._climate.turn_off()
+            await self._channel.turn_off()
 
     async def async_turn_on(self) -> None:
         """Turn the device on."""
-        await self._climate.turn_on()
+        await self._channel.turn_on()
 
     async def async_turn_off(self) -> None:
         """Turn the device off."""
-        await self._climate.turn_off()
+        await self._channel.turn_off()
 
     async def async_set_preset_mode(self, preset_mode) -> None:
         """Set new preset mode."""
         if preset_mode == "eco":
-            await self._climate.eco_on()
+            await self._channel.eco_on()
         else:
-            await self._climate.eco_off()
+            await self._channel.eco_off()
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         temperature = kwargs.get(ATTR_TEMPERATURE)
-        await self._climate.set_temperature(temperature)
+        await self._channel.set_temperature(temperature)
 
     async def async_update(self, **kwargs: Any) -> None:
         """Update the switch state."""
-        await self._climate.refresh_state()
+        await self._channel.refresh_state()

--- a/custom_components/abbfreeathome_ci/climate.py
+++ b/custom_components/abbfreeathome_ci/climate.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN, MANUFACTURER
 
 
 async def async_setup_entry(
@@ -98,8 +98,9 @@ class FreeAtHomeClimateEntity(ClimateEntity):
                     )
                 },
                 name=self._channel.channel_name,
-                manufacturer="ABB Busch-Jaeger",
+                manufacturer=MANUFACTURER,
                 serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                hw_version=f"{self._channel.device.device_id} (sub)",
                 suggested_area=self._channel.room_name,
                 via_device=(DOMAIN, self._channel.device_serial),
             )

--- a/custom_components/abbfreeathome_ci/config_flow.py
+++ b/custom_components/abbfreeathome_ci/config_flow.py
@@ -29,6 +29,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
+    CONF_CREATE_SUBDEVICES,
     CONF_INCLUDE_ORPHAN_CHANNELS,
     CONF_INCLUDE_VIRTUAL_DEVICES,
     CONF_SERIAL,
@@ -44,6 +45,7 @@ def _schema_with_defaults(
     username: str | None = None,
     include_orphan_channels: bool = False,
     include_virtual_devices: bool = False,
+    create_subdevices: bool = False,
     step_id: str = "user",
 ) -> vol.Schema:
     schema = vol.Schema({})
@@ -61,6 +63,7 @@ def _schema_with_defaults(
             vol.Optional(
                 CONF_INCLUDE_VIRTUAL_DEVICES, default=include_virtual_devices
             ): bool,
+            vol.Optional(CONF_CREATE_SUBDEVICES, default=create_subdevices): bool,
         }
     )
 
@@ -119,7 +122,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for ABB-free@home."""
 
     VERSION = 1
-    MINOR_VERSION = 3
+    MINOR_VERSION = 4
     CONNECTION_CLASS = CONN_CLASS_LOCAL_PUSH
 
     def __init__(self) -> None:
@@ -133,6 +136,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._username: str | None = None
         self._include_orphan_channels: bool = False
         self._include_virtual_devices: bool = False
+        self._create_subdevices: bool = False
 
     async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
         """Handle import from yaml configuration."""
@@ -173,6 +177,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._password = import_data[CONF_PASSWORD]
         self._include_orphan_channels = import_data[CONF_INCLUDE_ORPHAN_CHANNELS]
         self._include_virtual_devices = import_data[CONF_INCLUDE_VIRTUAL_DEVICES]
+        self._create_subdevices = import_data[CONF_CREATE_SUBDEVICES]
 
         # If SysAP already exists, update configuration and abort.
         await self.async_set_unique_id(settings.serial_number)
@@ -183,6 +188,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_PASSWORD: self._password,
                 CONF_INCLUDE_ORPHAN_CHANNELS: self._include_orphan_channels,
                 CONF_INCLUDE_VIRTUAL_DEVICES: self._include_virtual_devices,
+                CONF_CREATE_SUBDEVICES: self._create_subdevices,
             }
         )
 
@@ -228,6 +234,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._password = user_input[CONF_PASSWORD]
         self._include_orphan_channels = user_input[CONF_INCLUDE_ORPHAN_CHANNELS]
         self._include_virtual_devices = user_input[CONF_INCLUDE_VIRTUAL_DEVICES]
+        self._create_subdevices = user_input[CONF_CREATE_SUBDEVICES]
 
         return self._async_create_entry()
 
@@ -281,6 +288,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._password = user_input[CONF_PASSWORD]
         self._include_orphan_channels = user_input[CONF_INCLUDE_ORPHAN_CHANNELS]
         self._include_virtual_devices = user_input[CONF_INCLUDE_VIRTUAL_DEVICES]
+        self._create_subdevices = user_input[CONF_CREATE_SUBDEVICES]
 
         return self._async_create_entry()
 
@@ -299,6 +307,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._serial_number = entry.data[CONF_SERIAL]
         self._include_orphan_channels = entry.data[CONF_INCLUDE_ORPHAN_CHANNELS]
         self._include_virtual_devices = entry.data[CONF_INCLUDE_VIRTUAL_DEVICES]
+        self._create_subdevices = entry.data[CONF_CREATE_SUBDEVICES]
 
         if user_input is None:
             return self._async_show_setup_form(
@@ -306,6 +315,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
                 username=self._username,
                 include_orphan_channels=self._include_orphan_channels,
                 include_virtual_devices=self._include_virtual_devices,
+                create_subdevices=self._create_subdevices,
             )
 
         errors = await validate_api(
@@ -322,6 +332,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._password = user_input[CONF_PASSWORD]
         self._include_orphan_channels = user_input[CONF_INCLUDE_ORPHAN_CHANNELS]
         self._include_virtual_devices = user_input[CONF_INCLUDE_VIRTUAL_DEVICES]
+        self._create_subdevices = user_input[CONF_CREATE_SUBDEVICES]
 
         return self._async_update_reload_and_abort()
 
@@ -334,6 +345,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         username: str | None = None,
         include_orphan_channels: bool = False,
         include_virtual_devices: bool = False,
+        create_subdevices: bool = False,
     ) -> ConfigFlowResult:
         """Show the setup form to the user."""
         description_placeholders: Mapping[str, str | None] = {}
@@ -355,6 +367,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
                 username=username,
                 include_orphan_channels=include_orphan_channels,
                 include_virtual_devices=include_virtual_devices,
+                create_subdevices=create_subdevices,
             ),
             errors=errors or {},
             description_placeholders=description_placeholders,
@@ -372,6 +385,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_PASSWORD: self._password,
                 CONF_INCLUDE_ORPHAN_CHANNELS: self._include_orphan_channels,
                 CONF_INCLUDE_VIRTUAL_DEVICES: self._include_virtual_devices,
+                CONF_CREATE_SUBDEVICES: self._create_subdevices,
             },
         )
 
@@ -384,5 +398,6 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_PASSWORD: self._password,
                 CONF_INCLUDE_ORPHAN_CHANNELS: self._include_orphan_channels,
                 CONF_INCLUDE_VIRTUAL_DEVICES: self._include_virtual_devices,
+                CONF_CREATE_SUBDEVICES: self._create_subdevices,
             },
         )

--- a/custom_components/abbfreeathome_ci/const.py
+++ b/custom_components/abbfreeathome_ci/const.py
@@ -6,6 +6,7 @@ DOMAIN = "abbfreeathome_ci"
 CONF_SERIAL = "serial"
 CONF_INCLUDE_ORPHAN_CHANNELS = "include_orphan_channels"
 CONF_INCLUDE_VIRTUAL_DEVICES = "include_virtual_devices"
+CONF_CREATE_SUBDEVICES = "create_subdevices"
 
 # SysAP Settings
 SYSAP_VERSION = "sysap_version"

--- a/custom_components/abbfreeathome_ci/const.py
+++ b/custom_components/abbfreeathome_ci/const.py
@@ -1,6 +1,7 @@
 """Constants for the ABB-free@home integration."""
 
 DOMAIN = "abbfreeathome_ci"
+MANUFACTURER = "ABB Busch-Jaeger"
 
 # Domain Configuration
 CONF_SERIAL = "serial"

--- a/custom_components/abbfreeathome_ci/cover.py
+++ b/custom_components/abbfreeathome_ci/cover.py
@@ -135,28 +135,21 @@ class FreeAtHomeCoverEntity(CoverEntity):
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
         if self._create_subdevices and self._channel.device.is_multi_device:
-            return {
-                "identifiers": {
+            return DeviceInfo(
+                identifiers={
                     (
                         DOMAIN,
                         f"{self._channel.device_serial}_{self._channel.channel_id}",
                     )
                 },
-                "name": self._channel.channel_name,
-                "manufacturer": "ABB Busch-Jaeger",
-                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
-                "suggested_area": self._channel.room_name,
-                "via_device": (DOMAIN, self._channel.device_serial),
-            }
+                name=self._channel.channel_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                suggested_area=self._channel.room_name,
+                via_device=(DOMAIN, self._channel.device_serial),
+            )
 
-        return {
-            "identifiers": {(DOMAIN, self._channel.device_serial)},
-            "name": self._channel.device_name,
-            "manufacturer": "ABB Busch-Jaeger",
-            "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.device.room_name,
-            "via_device": (DOMAIN, self._sysap_serial_number),
-        }
+        return DeviceInfo(identifiers={(DOMAIN, self._channel.device_serial)})
 
     @property
     def current_cover_position(self) -> int:

--- a/custom_components/abbfreeathome_ci/cover.py
+++ b/custom_components/abbfreeathome_ci/cover.py
@@ -21,7 +21,6 @@ from homeassistant.components.cover import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -70,9 +69,7 @@ async def async_setup_entry(
                 entity_description_kwargs={"key": key}
                 | description.get("entity_description_kwargs"),
                 sysap_serial_number=entry.data[CONF_SERIAL],
-                hass=hass,
                 create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
-                config_entry_id=entry.entry_id,
             )
             for channel in free_at_home.get_channels_by_class(
                 channel_class=description.get("channel_class")
@@ -94,9 +91,7 @@ class FreeAtHomeCoverEntity(CoverEntity):
         channel: AtticWindowActuator | AwningActuator | BlindActuator | ShutterActuator,
         entity_description_kwargs: dict[str:Any],
         sysap_serial_number: str,
-        hass: HomeAssistant,
         create_subdevices: bool,
-        config_entry_id: str,
     ) -> None:
         """Initialize the cover."""
         super().__init__()
@@ -109,18 +104,6 @@ class FreeAtHomeCoverEntity(CoverEntity):
             name=channel.channel_name,
             **entity_description_kwargs,
         )
-
-        if self._create_subdevices and self._channel.device.floor is None:
-            device_registry = dr.async_get(hass)
-            device_registry.async_get_or_create(
-                config_entry_id=config_entry_id,
-                identifiers={(DOMAIN, self._channel.device_serial)},
-                name=self._channel.device_name,
-                manufacturer="ABB Busch-Jaeger",
-                serial_number=self._channel.device_serial,
-                suggested_area=None,
-                via_device=(DOMAIN, self._sysap_serial_number),
-            )
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
@@ -151,7 +134,7 @@ class FreeAtHomeCoverEntity(CoverEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
-        if self._create_subdevices and self._channel.device.floor is None:
+        if self._create_subdevices and self._channel.device.is_multi_device:
             return {
                 "identifiers": {
                     (

--- a/custom_components/abbfreeathome_ci/cover.py
+++ b/custom_components/abbfreeathome_ci/cover.py
@@ -21,10 +21,11 @@ from homeassistant.components.cover import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
 
 SELECT_DESCRIPTIONS = {
     "AtticWindowActuator": {
@@ -69,6 +70,9 @@ async def async_setup_entry(
                 entity_description_kwargs={"key": key}
                 | description.get("entity_description_kwargs"),
                 sysap_serial_number=entry.data[CONF_SERIAL],
+                hass=hass,
+                create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
+                config_entry_id=entry.entry_id,
             )
             for channel in free_at_home.get_channels_by_class(
                 channel_class=description.get("channel_class")
@@ -90,17 +94,33 @@ class FreeAtHomeCoverEntity(CoverEntity):
         channel: AtticWindowActuator | AwningActuator | BlindActuator | ShutterActuator,
         entity_description_kwargs: dict[str:Any],
         sysap_serial_number: str,
+        hass: HomeAssistant,
+        create_subdevices: bool,
+        config_entry_id: str,
     ) -> None:
         """Initialize the cover."""
         super().__init__()
         self._channel = channel
         self._sysap_serial_number = sysap_serial_number
+        self._create_subdevices = create_subdevices
 
         self.entity_description = CoverEntityDescription(
             has_entity_name=True,
             name=channel.channel_name,
             **entity_description_kwargs,
         )
+
+        if self._create_subdevices and self._channel.device.floor is None:
+            device_registry = dr.async_get(hass)
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry_id,
+                identifiers={(DOMAIN, self._channel.device_serial)},
+                name=self._channel.device_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=self._channel.device_serial,
+                suggested_area=None,
+                via_device=(DOMAIN, self._sysap_serial_number),
+            )
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
@@ -131,12 +151,27 @@ class FreeAtHomeCoverEntity(CoverEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
+        if self._create_subdevices and self._channel.device.floor is None:
+            return {
+                "identifiers": {
+                    (
+                        DOMAIN,
+                        f"{self._channel.device_serial}_{self._channel.channel_id}",
+                    )
+                },
+                "name": self._channel.channel_name,
+                "manufacturer": "ABB Busch-Jaeger",
+                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
+                "suggested_area": self._channel.room_name,
+                "via_device": (DOMAIN, self._channel.device_serial),
+            }
+
         return {
             "identifiers": {(DOMAIN, self._channel.device_serial)},
             "name": self._channel.device_name,
-            "manufacturer": "ABB busch-jaeger",
+            "manufacturer": "ABB Busch-Jaeger",
             "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.room_name,
+            "suggested_area": self._channel.device.room_name,
             "via_device": (DOMAIN, self._sysap_serial_number),
         }
 

--- a/custom_components/abbfreeathome_ci/cover.py
+++ b/custom_components/abbfreeathome_ci/cover.py
@@ -24,7 +24,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN, MANUFACTURER
 
 SELECT_DESCRIPTIONS = {
     "AtticWindowActuator": {
@@ -143,8 +143,9 @@ class FreeAtHomeCoverEntity(CoverEntity):
                     )
                 },
                 name=self._channel.channel_name,
-                manufacturer="ABB Busch-Jaeger",
+                manufacturer=MANUFACTURER,
                 serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                hw_version=f"{self._channel.device.device_id} (sub)",
                 suggested_area=self._channel.room_name,
                 via_device=(DOMAIN, self._channel.device_serial),
             )

--- a/custom_components/abbfreeathome_ci/event.py
+++ b/custom_components/abbfreeathome_ci/event.py
@@ -24,7 +24,6 @@ from homeassistant.components.event import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -117,9 +116,7 @@ async def async_setup_entry(
                 entity_description_kwargs={"key": key}
                 | description.get("entity_description_kwargs"),
                 sysap_serial_number=entry.data[CONF_SERIAL],
-                hass=hass,
                 create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
-                config_entry_id=entry.entry_id,
                 event_type_callback=description.get("event_type_callback"),
             )
             for channel in free_at_home.get_channels_by_class(
@@ -142,9 +139,7 @@ class FreeAtHomeEventEntity(EventEntity):
         state_attribute: str,
         entity_description_kwargs: dict[str:Any],
         sysap_serial_number: str,
-        hass: HomeAssistant,
         create_subdevices: bool,
-        config_entry_id: str,
         event_type_callback: callback,
     ) -> None:
         """Initialize the sensor."""
@@ -161,18 +156,6 @@ class FreeAtHomeEventEntity(EventEntity):
             translation_placeholders={"channel_id": channel.channel_id},
             **entity_description_kwargs,
         )
-
-        if self._create_subdevices and self._channel.device.floor is None:
-            device_registry = dr.async_get(hass)
-            device_registry.async_get_or_create(
-                config_entry_id=config_entry_id,
-                identifiers={(DOMAIN, self._channel.device_serial)},
-                name=self._channel.device_name,
-                manufacturer="ABB Busch-Jaeger",
-                serial_number=self._channel.device_serial,
-                suggested_area=None,
-                via_device=(DOMAIN, self._sysap_serial_number),
-            )
 
     @callback
     def _async_handle_event(self) -> None:
@@ -215,7 +198,7 @@ class FreeAtHomeEventEntity(EventEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
-        if self._create_subdevices and self._channel.device.floor is None:
+        if self._create_subdevices and self._channel.device.is_multi_device:
             return {
                 "identifiers": {
                     (

--- a/custom_components/abbfreeathome_ci/event.py
+++ b/custom_components/abbfreeathome_ci/event.py
@@ -24,10 +24,11 @@ from homeassistant.components.event import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
 
 EVENT_DESCRIPTIONS = {
     "EventBlindSensorState": {
@@ -116,6 +117,9 @@ async def async_setup_entry(
                 entity_description_kwargs={"key": key}
                 | description.get("entity_description_kwargs"),
                 sysap_serial_number=entry.data[CONF_SERIAL],
+                hass=hass,
+                create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
+                config_entry_id=entry.entry_id,
                 event_type_callback=description.get("event_type_callback"),
             )
             for channel in free_at_home.get_channels_by_class(
@@ -138,6 +142,9 @@ class FreeAtHomeEventEntity(EventEntity):
         state_attribute: str,
         entity_description_kwargs: dict[str:Any],
         sysap_serial_number: str,
+        hass: HomeAssistant,
+        create_subdevices: bool,
+        config_entry_id: str,
         event_type_callback: callback,
     ) -> None:
         """Initialize the sensor."""
@@ -145,6 +152,7 @@ class FreeAtHomeEventEntity(EventEntity):
         self._channel = channel
         self._state_attribute = state_attribute
         self._sysap_serial_number = sysap_serial_number
+        self._create_subdevices = create_subdevices
         self._event_type_callback = event_type_callback
 
         self.entity_description = EventEntityDescription(
@@ -153,6 +161,18 @@ class FreeAtHomeEventEntity(EventEntity):
             translation_placeholders={"channel_id": channel.channel_id},
             **entity_description_kwargs,
         )
+
+        if self._create_subdevices and self._channel.device.floor is None:
+            device_registry = dr.async_get(hass)
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry_id,
+                identifiers={(DOMAIN, self._channel.device_serial)},
+                name=self._channel.device_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=self._channel.device_serial,
+                suggested_area=None,
+                via_device=(DOMAIN, self._sysap_serial_number),
+            )
 
     @callback
     def _async_handle_event(self) -> None:
@@ -195,12 +215,27 @@ class FreeAtHomeEventEntity(EventEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
+        if self._create_subdevices and self._channel.device.floor is None:
+            return {
+                "identifiers": {
+                    (
+                        DOMAIN,
+                        f"{self._channel.device_serial}_{self._channel.channel_id}",
+                    )
+                },
+                "name": self._channel.channel_name,
+                "manufacturer": "ABB Busch-Jaeger",
+                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
+                "suggested_area": self._channel.room_name,
+                "via_device": (DOMAIN, self._channel.device_serial),
+            }
+
         return {
             "identifiers": {(DOMAIN, self._channel.device_serial)},
             "name": self._channel.device_name,
-            "manufacturer": "ABB busch-jaeger",
+            "manufacturer": "ABB Busch-Jaeger",
             "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.room_name,
+            "suggested_area": self._channel.device.room_name,
             "via_device": (DOMAIN, self._sysap_serial_number),
         }
 

--- a/custom_components/abbfreeathome_ci/event.py
+++ b/custom_components/abbfreeathome_ci/event.py
@@ -199,28 +199,21 @@ class FreeAtHomeEventEntity(EventEntity):
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
         if self._create_subdevices and self._channel.device.is_multi_device:
-            return {
-                "identifiers": {
+            return DeviceInfo(
+                identifiers={
                     (
                         DOMAIN,
                         f"{self._channel.device_serial}_{self._channel.channel_id}",
                     )
                 },
-                "name": self._channel.channel_name,
-                "manufacturer": "ABB Busch-Jaeger",
-                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
-                "suggested_area": self._channel.room_name,
-                "via_device": (DOMAIN, self._channel.device_serial),
-            }
+                name=self._channel.channel_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                suggested_area=self._channel.room_name,
+                via_device=(DOMAIN, self._channel.device_serial),
+            )
 
-        return {
-            "identifiers": {(DOMAIN, self._channel.device_serial)},
-            "name": self._channel.device_name,
-            "manufacturer": "ABB Busch-Jaeger",
-            "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.device.room_name,
-            "via_device": (DOMAIN, self._sysap_serial_number),
-        }
+        return DeviceInfo(identifiers={(DOMAIN, self._channel.device_serial)})
 
     @property
     def unique_id(self) -> str | None:

--- a/custom_components/abbfreeathome_ci/event.py
+++ b/custom_components/abbfreeathome_ci/event.py
@@ -27,7 +27,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN, MANUFACTURER
 
 EVENT_DESCRIPTIONS = {
     "EventBlindSensorState": {
@@ -207,8 +207,9 @@ class FreeAtHomeEventEntity(EventEntity):
                     )
                 },
                 name=self._channel.channel_name,
-                manufacturer="ABB Busch-Jaeger",
+                manufacturer=MANUFACTURER,
                 serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                hw_version=f"{self._channel.device.device_id} (sub)",
                 suggested_area=self._channel.room_name,
                 via_device=(DOMAIN, self._channel.device_serial),
             )

--- a/custom_components/abbfreeathome_ci/light.py
+++ b/custom_components/abbfreeathome_ci/light.py
@@ -110,28 +110,21 @@ class FreeAtHomeLightEntity(LightEntity):
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
         if self._create_subdevices and self._channel.device.is_multi_device:
-            return {
-                "identifiers": {
+            return DeviceInfo(
+                identifiers={
                     (
                         DOMAIN,
                         f"{self._channel.device_serial}_{self._channel.channel_id}",
                     )
                 },
-                "name": self._channel.channel_name,
-                "manufacturer": "ABB Busch-Jaeger",
-                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
-                "suggested_area": self._channel.room_name,
-                "via_device": (DOMAIN, self._channel.device_serial),
-            }
+                name=self._channel.channel_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                suggested_area=self._channel.room_name,
+                via_device=(DOMAIN, self._channel.device_serial),
+            )
 
-        return {
-            "identifiers": {(DOMAIN, self._channel.device_serial)},
-            "name": self._channel.device_name,
-            "manufacturer": "ABB Busch-Jaeger",
-            "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.device.room_name,
-            "via_device": (DOMAIN, self._sysap_serial_number),
-        }
+        return DeviceInfo(identifiers={(DOMAIN, self._channel.device_serial)})
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/abbfreeathome_ci/light.py
+++ b/custom_components/abbfreeathome_ci/light.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.color import brightness_to_value, value_to_brightness
 
-from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN, MANUFACTURER
 
 BRIGHTNESS_SCALE = (1, 100)
 
@@ -118,8 +118,9 @@ class FreeAtHomeLightEntity(LightEntity):
                     )
                 },
                 name=self._channel.channel_name,
-                manufacturer="ABB Busch-Jaeger",
+                manufacturer=MANUFACTURER,
                 serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                hw_version=f"{self._channel.device.device_id} (sub)",
                 suggested_area=self._channel.room_name,
                 via_device=(DOMAIN, self._channel.device_serial),
             )

--- a/custom_components/abbfreeathome_ci/light.py
+++ b/custom_components/abbfreeathome_ci/light.py
@@ -17,11 +17,12 @@ from homeassistant.components.light import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.color import brightness_to_value, value_to_brightness
 
-from .const import CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
 
 BRIGHTNESS_SCALE = (1, 100)
 
@@ -35,12 +36,24 @@ async def async_setup_entry(
     free_at_home: FreeAtHome = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities(
-        FreeAtHomeLightEntity(light, sysap_serial_number=entry.data[CONF_SERIAL])
-        for light in free_at_home.get_channels_by_class(channel_class=DimmingActuator)
+        FreeAtHomeLightEntity(
+            channel,
+            sysap_serial_number=entry.data[CONF_SERIAL],
+            hass=hass,
+            create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
+            config_entry_id=entry.entry_id,
+        )
+        for channel in free_at_home.get_channels_by_class(channel_class=DimmingActuator)
     )
     async_add_entities(
-        FreeAtHomeLightEntity(light, sysap_serial_number=entry.data[CONF_SERIAL])
-        for light in free_at_home.get_channels_by_class(
+        FreeAtHomeLightEntity(
+            channel,
+            sysap_serial_number=entry.data[CONF_SERIAL],
+            hass=hass,
+            create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
+            config_entry_id=entry.entry_id,
+        )
+        for channel in free_at_home.get_channels_by_class(
             channel_class=ColorTemperatureActuator
         )
     )
@@ -57,28 +70,44 @@ class FreeAtHomeLightEntity(LightEntity):
 
     def __init__(
         self,
-        light: DimmingActuator | ColorTemperatureActuator,
+        channel: DimmingActuator | ColorTemperatureActuator,
         sysap_serial_number: str,
+        hass: HomeAssistant,
+        create_subdevices: bool,
+        config_entry_id: str,
     ) -> None:
         """Initialize the light."""
         super().__init__()
-        self._light = light
+        self._channel = channel
         self._sysap_serial_number = sysap_serial_number
+        self._create_subdevices = create_subdevices
 
         self.entity_description = LightEntityDescription(
             key="light",
-            name=light.channel_name,
+            name=channel.channel_name,
         )
+
+        if self._create_subdevices and self._channel.device.floor is None:
+            device_registry = dr.async_get(hass)
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry_id,
+                identifiers={(DOMAIN, self._channel.device_serial)},
+                name=self._channel.device_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=self._channel.device_serial,
+                suggested_area=None,
+                via_device=(DOMAIN, self._sysap_serial_number),
+            )
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
         for _callback_attribute in self._callback_attributes:
-            self._light.register_callback(
+            self._channel.register_callback(
                 callback_attribute=_callback_attribute,
                 callback=self.async_write_ha_state,
             )
-        if hasattr(self._light, "color_temperature"):
-            await self._light.register_callback(
+        if hasattr(self._channel, "color_temperature"):
+            await self._channel.register_callback(
                 callback_attribute="color_temperature",
                 callback=self.async_write_ha_state,
             )
@@ -86,12 +115,12 @@ class FreeAtHomeLightEntity(LightEntity):
     async def async_will_remove_from_hass(self) -> None:
         """Entity being removed from hass."""
         for _callback_attribute in self._callback_attributes:
-            self._light.remove_callback(
+            self._channel.remove_callback(
                 callback_attribute=_callback_attribute,
                 callback=self.async_write_ha_state,
             )
-        if hasattr(self._light, "color_temperature"):
-            await self._light.remove_callback(
+        if hasattr(self._channel, "color_temperature"):
+            await self._channel.remove_callback(
                 callback_attribute="color_temperature",
                 callback=self.async_write_ha_state,
             )
@@ -99,40 +128,55 @@ class FreeAtHomeLightEntity(LightEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
+        if self._create_subdevices and self._channel.device.floor is None:
+            return {
+                "identifiers": {
+                    (
+                        DOMAIN,
+                        f"{self._channel.device_serial}_{self._channel.channel_id}",
+                    )
+                },
+                "name": self._channel.channel_name,
+                "manufacturer": "ABB Busch-Jaeger",
+                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
+                "suggested_area": self._channel.room_name,
+                "via_device": (DOMAIN, self._channel.device_serial),
+            }
+
         return {
-            "identifiers": {(DOMAIN, self._light.device_serial)},
-            "name": self._light.device_name,
-            "manufacturer": "ABB busch-jaeger",
-            "serial_number": self._light.device_serial,
-            "suggested_area": self._light.room_name,
+            "identifiers": {(DOMAIN, self._channel.device_serial)},
+            "name": self._channel.device_name,
+            "manufacturer": "ABB Busch-Jaeger",
+            "serial_number": self._channel.device_serial,
+            "suggested_area": self._channel.device.room_name,
             "via_device": (DOMAIN, self._sysap_serial_number),
         }
 
     @property
     def is_on(self) -> bool | None:
         """Return state of the light."""
-        return self._light.state
+        return self._channel.state
 
     @property
     def brightness(self) -> int | None:
         """Return the current brightness."""
-        return value_to_brightness(BRIGHTNESS_SCALE, self._light.brightness)
+        return value_to_brightness(BRIGHTNESS_SCALE, self._channel.brightness)
 
     @property
     def color_temp_kelvin(self) -> int | None:
         """Return the color temperature in Kelvin."""
         return map_range(
-            self._light.color_temperature,
+            self._channel.color_temperature,
             0,
             100,
-            self._light.color_temperature_warmest,
-            self._light.color_temperature_coolest,
+            self._channel.color_temperature_warmest,
+            self._channel.color_temperature_coolest,
         )
 
     @property
     def color_mode(self) -> str | None:
         """Return the color mode of the light."""
-        if hasattr(self._light, "color_temperature"):
+        if hasattr(self._channel, "color_temperature"):
             return ColorMode.COLOR_TEMP
         return ColorMode.BRIGHTNESS
 
@@ -141,7 +185,7 @@ class FreeAtHomeLightEntity(LightEntity):
         """Flag supported color modes."""
         _color_modes = {ColorMode.BRIGHTNESS}
 
-        if hasattr(self._light, "color_temperature"):
+        if hasattr(self._channel, "color_temperature"):
             _color_modes.add(ColorMode.COLOR_TEMP)
 
         return _color_modes
@@ -149,38 +193,38 @@ class FreeAtHomeLightEntity(LightEntity):
     @property
     def unique_id(self) -> str | None:
         """Return a unique ID."""
-        return f"{self._light.device_serial}_{self._light.channel_id}_light"
+        return f"{self._channel.device_serial}_{self._channel.channel_id}_light"
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         if ATTR_BRIGHTNESS in kwargs:
-            await self._light.set_brightness(
+            await self._channel.set_brightness(
                 int(brightness_to_value(BRIGHTNESS_SCALE, kwargs[ATTR_BRIGHTNESS]))
             )
             return
 
         if ATTR_COLOR_TEMP_KELVIN in kwargs:
-            if hasattr(self._light, "color_temperature"):
-                await self._light.set_color_temperature(
+            if hasattr(self._channel, "color_temperature"):
+                await self._channel.set_color_temperature(
                     map_range(
                         kwargs[ATTR_COLOR_TEMP_KELVIN],
-                        self._light.color_temperature_warmest,
-                        self._light.color_temperature_coolest,
+                        self._channel.color_temperature_warmest,
+                        self._channel.color_temperature_coolest,
                         0,
                         100,
                     )
                 )
             return
 
-        await self._light.turn_on()
+        await self._channel.turn_on()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
-        await self._light.turn_off()
+        await self._channel.turn_off()
 
     async def async_update(self, **kwargs: Any) -> None:
         """Update the light state."""
-        await self._light.refresh_state()
+        await self._channel.refresh_state()
 
 
 def map_range(

--- a/custom_components/abbfreeathome_ci/lock.py
+++ b/custom_components/abbfreeathome_ci/lock.py
@@ -8,10 +8,11 @@ from abbfreeathome.channels.des_door_opener_actuator import DesDoorOpenerActuato
 from homeassistant.components.lock import LockEntity, LockEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
 
 
 async def async_setup_entry(
@@ -23,8 +24,14 @@ async def async_setup_entry(
     free_at_home: FreeAtHome = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities(
-        FreeAtHomeLockEntity(lock, sysap_serial_number=entry.data[CONF_SERIAL])
-        for lock in free_at_home.get_channels_by_class(
+        FreeAtHomeLockEntity(
+            channel,
+            sysap_serial_number=entry.data[CONF_SERIAL],
+            hass=hass,
+            create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
+            config_entry_id=entry.entry_id,
+        )
+        for channel in free_at_home.get_channels_by_class(
             channel_class=DesDoorOpenerActuator
         )
     )
@@ -35,59 +42,94 @@ class FreeAtHomeLockEntity(LockEntity):
 
     _attr_should_poll: bool = False
 
-    def __init__(self, lock: DesDoorOpenerActuator, sysap_serial_number: str) -> None:
-        """Initialize the valve."""
+    def __init__(
+        self,
+        channel: DesDoorOpenerActuator,
+        sysap_serial_number: str,
+        hass: HomeAssistant,
+        create_subdevices: bool,
+        config_entry_id: str,
+    ) -> None:
+        """Initialize the lock."""
         super().__init__()
-        self._lock = lock
+        self._channel = channel
         self._sysap_serial_number = sysap_serial_number
+        self._create_subdevices = create_subdevices
 
         self.entity_description = LockEntityDescription(
             key="DesDoorOpenerActuatorLock",
-            name=lock.channel_name,
+            name=channel.channel_name,
         )
+
+        if self._create_subdevices and self._channel.device.floor is None:
+            device_registry = dr.async_get(hass)
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry_id,
+                identifiers={(DOMAIN, self._channel.device_serial)},
+                name=self._channel.device_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=self._channel.device_serial,
+                suggested_area=None,
+                via_device=(DOMAIN, self._sysap_serial_number),
+            )
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
-        self._lock.register_callback(
+        self._channel.register_callback(
             callback_attribute="state", callback=self.async_write_ha_state
         )
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity being removed from hass."""
-        self._lock.remove_callback(
+        self._channel.remove_callback(
             callback_attribute="state", callback=self.async_write_ha_state
         )
 
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
+        if self._create_subdevices and self._channel.device.floor is None:
+            return {
+                "identifiers": {
+                    (
+                        DOMAIN,
+                        f"{self._channel.device_serial}_{self._channel.channel_id}",
+                    )
+                },
+                "name": self._channel.channel_name,
+                "manufacturer": "ABB Busch-Jaeger",
+                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
+                "suggested_area": self._channel.room_name,
+                "via_device": (DOMAIN, self._channel.device_serial),
+            }
+
         return {
-            "identifiers": {(DOMAIN, self._lock.device_serial)},
-            "name": self._lock.device_name,
-            "manufacturer": "ABB busch-jaeger",
-            "serial_number": self._lock.device_serial,
-            "suggested_area": self._lock.room_name,
+            "identifiers": {(DOMAIN, self._channel.device_serial)},
+            "name": self._channel.device_name,
+            "manufacturer": "ABB Busch-Jaeger",
+            "serial_number": self._channel.device_serial,
+            "suggested_area": self._channel.device.room_name,
             "via_device": (DOMAIN, self._sysap_serial_number),
         }
 
     @property
     def is_locked(self) -> bool | None:
         """Return if device is on."""
-        return self._lock.state is False
+        return self._channel.state is False
 
     @property
     def unique_id(self) -> str | None:
         """Return a unique ID."""
-        return f"{self._lock.device_serial}_{self._lock.channel_id}_valve"
+        return f"{self._channel.device_serial}_{self._channel.channel_id}_valve"
 
     async def async_lock(self, **kwargs):
         """Lock the device."""
-        await self._lock.lock()
+        await self._channel.lock()
 
     async def async_unlock(self, **kwargs):
         """Unlock the device."""
-        await self._lock.unlock()
+        await self._channel.unlock()
 
     async def async_update(self, **kwargs: Any) -> None:
         """Update the lock state."""
-        await self._lock.refresh_state()
+        await self._channel.refresh_state()

--- a/custom_components/abbfreeathome_ci/lock.py
+++ b/custom_components/abbfreeathome_ci/lock.py
@@ -72,28 +72,21 @@ class FreeAtHomeLockEntity(LockEntity):
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
         if self._create_subdevices and self._channel.device.is_multi_device:
-            return {
-                "identifiers": {
+            return DeviceInfo(
+                identifiers={
                     (
                         DOMAIN,
                         f"{self._channel.device_serial}_{self._channel.channel_id}",
                     )
                 },
-                "name": self._channel.channel_name,
-                "manufacturer": "ABB Busch-Jaeger",
-                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
-                "suggested_area": self._channel.room_name,
-                "via_device": (DOMAIN, self._channel.device_serial),
-            }
+                name=self._channel.channel_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                suggested_area=self._channel.room_name,
+                via_device=(DOMAIN, self._channel.device_serial),
+            )
 
-        return {
-            "identifiers": {(DOMAIN, self._channel.device_serial)},
-            "name": self._channel.device_name,
-            "manufacturer": "ABB Busch-Jaeger",
-            "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.device.room_name,
-            "via_device": (DOMAIN, self._sysap_serial_number),
-        }
+        return DeviceInfo(identifiers={(DOMAIN, self._channel.device_serial)})
 
     @property
     def is_locked(self) -> bool | None:

--- a/custom_components/abbfreeathome_ci/lock.py
+++ b/custom_components/abbfreeathome_ci/lock.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN, MANUFACTURER
 
 
 async def async_setup_entry(
@@ -80,8 +80,9 @@ class FreeAtHomeLockEntity(LockEntity):
                     )
                 },
                 name=self._channel.channel_name,
-                manufacturer="ABB Busch-Jaeger",
+                manufacturer=MANUFACTURER,
                 serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                hw_version=f"{self._channel.device.device_id} (sub)",
                 suggested_area=self._channel.room_name,
                 via_device=(DOMAIN, self._channel.device_serial),
             )

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -8,7 +8,7 @@
   "homekit": {},
   "iot_class": "local_push",
   "loggers": ["abbfreeathome"],
-  "requirements": ["local-abbfreeathome==3.0.0b3"],
+  "requirements": ["local-abbfreeathome==3.0.0b4"],
   "ssdp": [],
   "version": "1.7.0b1",
   "zeroconf": [

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -8,7 +8,7 @@
   "homekit": {},
   "iot_class": "local_push",
   "loggers": ["abbfreeathome"],
-  "requirements": ["local-abbfreeathome==3.0.0b2"],
+  "requirements": ["local-abbfreeathome==3.0.0b3"],
   "ssdp": [],
   "version": "1.7.0b1",
   "zeroconf": [

--- a/custom_components/abbfreeathome_ci/number.py
+++ b/custom_components/abbfreeathome_ci/number.py
@@ -30,10 +30,11 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
 
 NUMBER_DESCRIPTIONS = {
     "VirtualBrightnessSensor": {
@@ -271,6 +272,9 @@ async def async_setup_entry(
                 entity_description_kwargs={"key": key}
                 | description.get("entity_description_kwargs"),
                 sysap_serial_number=entry.data[CONF_SERIAL],
+                hass=hass,
+                create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
+                config_entry_id=entry.entry_id,
             )
             for channel in free_at_home.get_channels_by_class(
                 channel_class=description.get("channel_class")
@@ -290,12 +294,16 @@ class FreeAtHomeNumberEntity(NumberEntity):
         value_attribute: str,
         entity_description_kwargs: dict[str:Any],
         sysap_serial_number: str,
+        hass: HomeAssistant,
+        create_subdevices: bool,
+        config_entry_id: str,
     ) -> None:
-        """Initialize the switch."""
+        """Initialize the number."""
         super().__init__()
         self._channel = channel
         self._value_attribute = value_attribute
         self._sysap_serial_number = sysap_serial_number
+        self._create_subdevices = create_subdevices
 
         self.entity_description = NumberEntityDescription(
             has_entity_name=True,
@@ -303,6 +311,18 @@ class FreeAtHomeNumberEntity(NumberEntity):
             translation_placeholders={"channel_id": channel.channel_id},
             **entity_description_kwargs,
         )
+
+        if self._create_subdevices and self._channel.device.floor is None:
+            device_registry = dr.async_get(hass)
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry_id,
+                identifiers={(DOMAIN, self._channel.device_serial)},
+                name=self._channel.device_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=self._channel.device_serial,
+                suggested_area=None,
+                via_device=(DOMAIN, self._sysap_serial_number),
+            )
 
     async def async_added_to_hass(self) -> None:
         """Run when this entity has been added to HA."""
@@ -319,12 +339,27 @@ class FreeAtHomeNumberEntity(NumberEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
+        if self._create_subdevices and self._channel.device.floor is None:
+            return {
+                "identifiers": {
+                    (
+                        DOMAIN,
+                        f"{self._channel.device_serial}_{self._channel.channel_id}",
+                    )
+                },
+                "name": self._channel.channel_name,
+                "manufacturer": "ABB Busch-Jaeger",
+                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
+                "suggested_area": self._channel.room_name,
+                "via_device": (DOMAIN, self._channel.device_serial),
+            }
+
         return {
             "identifiers": {(DOMAIN, self._channel.device_serial)},
             "name": self._channel.device_name,
-            "manufacturer": "ABB busch-jaeger",
+            "manufacturer": "ABB Busch-Jaeger",
             "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.room_name,
+            "suggested_area": self._channel.device.room_name,
             "via_device": (DOMAIN, self._sysap_serial_number),
         }
 

--- a/custom_components/abbfreeathome_ci/number.py
+++ b/custom_components/abbfreeathome_ci/number.py
@@ -323,28 +323,21 @@ class FreeAtHomeNumberEntity(NumberEntity):
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
         if self._create_subdevices and self._channel.device.is_multi_device:
-            return {
-                "identifiers": {
+            return DeviceInfo(
+                identifiers={
                     (
                         DOMAIN,
                         f"{self._channel.device_serial}_{self._channel.channel_id}",
                     )
                 },
-                "name": self._channel.channel_name,
-                "manufacturer": "ABB Busch-Jaeger",
-                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
-                "suggested_area": self._channel.room_name,
-                "via_device": (DOMAIN, self._channel.device_serial),
-            }
+                name=self._channel.channel_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                suggested_area=self._channel.room_name,
+                via_device=(DOMAIN, self._channel.device_serial),
+            )
 
-        return {
-            "identifiers": {(DOMAIN, self._channel.device_serial)},
-            "name": self._channel.device_name,
-            "manufacturer": "ABB Busch-Jaeger",
-            "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.device.room_name,
-            "via_device": (DOMAIN, self._sysap_serial_number),
-        }
+        return DeviceInfo(identifiers={(DOMAIN, self._channel.device_serial)})
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/abbfreeathome_ci/number.py
+++ b/custom_components/abbfreeathome_ci/number.py
@@ -33,7 +33,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN, MANUFACTURER
 
 NUMBER_DESCRIPTIONS = {
     "VirtualBrightnessSensor": {
@@ -331,8 +331,9 @@ class FreeAtHomeNumberEntity(NumberEntity):
                     )
                 },
                 name=self._channel.channel_name,
-                manufacturer="ABB Busch-Jaeger",
+                manufacturer=MANUFACTURER,
                 serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                hw_version=f"{self._channel.device.device_id} (sub)",
                 suggested_area=self._channel.room_name,
                 via_device=(DOMAIN, self._channel.device_serial),
             )

--- a/custom_components/abbfreeathome_ci/number.py
+++ b/custom_components/abbfreeathome_ci/number.py
@@ -30,7 +30,6 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -272,9 +271,7 @@ async def async_setup_entry(
                 entity_description_kwargs={"key": key}
                 | description.get("entity_description_kwargs"),
                 sysap_serial_number=entry.data[CONF_SERIAL],
-                hass=hass,
                 create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
-                config_entry_id=entry.entry_id,
             )
             for channel in free_at_home.get_channels_by_class(
                 channel_class=description.get("channel_class")
@@ -294,9 +291,7 @@ class FreeAtHomeNumberEntity(NumberEntity):
         value_attribute: str,
         entity_description_kwargs: dict[str:Any],
         sysap_serial_number: str,
-        hass: HomeAssistant,
         create_subdevices: bool,
-        config_entry_id: str,
     ) -> None:
         """Initialize the number."""
         super().__init__()
@@ -311,18 +306,6 @@ class FreeAtHomeNumberEntity(NumberEntity):
             translation_placeholders={"channel_id": channel.channel_id},
             **entity_description_kwargs,
         )
-
-        if self._create_subdevices and self._channel.device.floor is None:
-            device_registry = dr.async_get(hass)
-            device_registry.async_get_or_create(
-                config_entry_id=config_entry_id,
-                identifiers={(DOMAIN, self._channel.device_serial)},
-                name=self._channel.device_name,
-                manufacturer="ABB Busch-Jaeger",
-                serial_number=self._channel.device_serial,
-                suggested_area=None,
-                via_device=(DOMAIN, self._sysap_serial_number),
-            )
 
     async def async_added_to_hass(self) -> None:
         """Run when this entity has been added to HA."""
@@ -339,7 +322,7 @@ class FreeAtHomeNumberEntity(NumberEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
-        if self._create_subdevices and self._channel.device.floor is None:
+        if self._create_subdevices and self._channel.device.is_multi_device:
             return {
                 "identifiers": {
                     (

--- a/custom_components/abbfreeathome_ci/select.py
+++ b/custom_components/abbfreeathome_ci/select.py
@@ -22,7 +22,6 @@ from abbfreeathome.channels.switch_actuator import (
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -127,9 +126,7 @@ async def async_setup_entry(
                 current_option_attribute=description.get("current_option_attribute"),
                 select_option_method=description.get("select_option_method"),
                 sysap_serial_number=entry.data[CONF_SERIAL],
-                hass=hass,
                 create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
-                config_entry_id=entry.entry_id,
             )
             for channel in free_at_home.get_channels_by_class(
                 channel_class=description.get("channel_class")
@@ -154,9 +151,7 @@ class FreeAtHomeSelectEntity(SelectEntity):
         current_option_attribute: str,
         select_option_method: str,
         sysap_serial_number: str,
-        hass: HomeAssistant,
         create_subdevices: bool,
-        config_entry_id: str,
     ) -> None:
         """Initialize the switch."""
         super().__init__()
@@ -176,18 +171,6 @@ class FreeAtHomeSelectEntity(SelectEntity):
             **entity_description_kwargs,
         )
 
-        if self._create_subdevices and self._channel.device.floor is None:
-            device_registry = dr.async_get(hass)
-            device_registry.async_get_or_create(
-                config_entry_id=config_entry_id,
-                identifiers={(DOMAIN, self._channel.device_serial)},
-                name=self._channel.device_name,
-                manufacturer="ABB Busch-Jaeger",
-                serial_number=self._channel.device_serial,
-                suggested_area=None,
-                via_device=(DOMAIN, self._sysap_serial_number),
-            )
-
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
         self._channel.register_callback(
@@ -205,7 +188,7 @@ class FreeAtHomeSelectEntity(SelectEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
-        if self._create_subdevices and self._channel.device.floor is None:
+        if self._create_subdevices and self._channel.device.is_multi_device:
             return {
                 "identifiers": {
                     (

--- a/custom_components/abbfreeathome_ci/select.py
+++ b/custom_components/abbfreeathome_ci/select.py
@@ -189,28 +189,21 @@ class FreeAtHomeSelectEntity(SelectEntity):
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
         if self._create_subdevices and self._channel.device.is_multi_device:
-            return {
-                "identifiers": {
+            return DeviceInfo(
+                identifiers={
                     (
                         DOMAIN,
                         f"{self._channel.device_serial}_{self._channel.channel_id}",
                     )
                 },
-                "name": self._channel.channel_name,
-                "manufacturer": "ABB Busch-Jaeger",
-                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
-                "suggested_area": self._channel.room_name,
-                "via_device": (DOMAIN, self._channel.device_serial),
-            }
+                name=self._channel.channel_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                suggested_area=self._channel.room_name,
+                via_device=(DOMAIN, self._channel.device_serial),
+            )
 
-        return {
-            "identifiers": {(DOMAIN, self._channel.device_serial)},
-            "name": self._channel.device_name,
-            "manufacturer": "ABB Busch-Jaeger",
-            "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.device.room_name,
-            "via_device": (DOMAIN, self._sysap_serial_number),
-        }
+        return DeviceInfo(identifiers={(DOMAIN, self._channel.device_serial)})
 
     @property
     def current_option(self) -> str | None:

--- a/custom_components/abbfreeathome_ci/select.py
+++ b/custom_components/abbfreeathome_ci/select.py
@@ -25,7 +25,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN, MANUFACTURER
 
 SELECT_DESCRIPTIONS = {
     "AtticWindowActuatorForcedPosition": {
@@ -197,8 +197,9 @@ class FreeAtHomeSelectEntity(SelectEntity):
                     )
                 },
                 name=self._channel.channel_name,
-                manufacturer="ABB Busch-Jaeger",
+                manufacturer=MANUFACTURER,
                 serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                hw_version=f"{self._channel.device.device_id} (sub)",
                 suggested_area=self._channel.room_name,
                 via_device=(DOMAIN, self._channel.device_serial),
             )

--- a/custom_components/abbfreeathome_ci/select.py
+++ b/custom_components/abbfreeathome_ci/select.py
@@ -22,10 +22,11 @@ from abbfreeathome.channels.switch_actuator import (
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
 
 SELECT_DESCRIPTIONS = {
     "AtticWindowActuatorForcedPosition": {
@@ -126,6 +127,9 @@ async def async_setup_entry(
                 current_option_attribute=description.get("current_option_attribute"),
                 select_option_method=description.get("select_option_method"),
                 sysap_serial_number=entry.data[CONF_SERIAL],
+                hass=hass,
+                create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
+                config_entry_id=entry.entry_id,
             )
             for channel in free_at_home.get_channels_by_class(
                 channel_class=description.get("channel_class")
@@ -150,6 +154,9 @@ class FreeAtHomeSelectEntity(SelectEntity):
         current_option_attribute: str,
         select_option_method: str,
         sysap_serial_number: str,
+        hass: HomeAssistant,
+        create_subdevices: bool,
+        config_entry_id: str,
     ) -> None:
         """Initialize the switch."""
         super().__init__()
@@ -157,6 +164,7 @@ class FreeAtHomeSelectEntity(SelectEntity):
         self._current_option_attribute = current_option_attribute
         self._select_option_method = select_option_method
         self._sysap_serial_number = sysap_serial_number
+        self._create_subdevices = create_subdevices
 
         self.entity_description = SelectEntityDescription(
             has_entity_name=True,
@@ -167,6 +175,18 @@ class FreeAtHomeSelectEntity(SelectEntity):
             },
             **entity_description_kwargs,
         )
+
+        if self._create_subdevices and self._channel.device.floor is None:
+            device_registry = dr.async_get(hass)
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry_id,
+                identifiers={(DOMAIN, self._channel.device_serial)},
+                name=self._channel.device_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=self._channel.device_serial,
+                suggested_area=None,
+                via_device=(DOMAIN, self._sysap_serial_number),
+            )
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
@@ -185,12 +205,27 @@ class FreeAtHomeSelectEntity(SelectEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
+        if self._create_subdevices and self._channel.device.floor is None:
+            return {
+                "identifiers": {
+                    (
+                        DOMAIN,
+                        f"{self._channel.device_serial}_{self._channel.channel_id}",
+                    )
+                },
+                "name": self._channel.channel_name,
+                "manufacturer": "ABB Busch-Jaeger",
+                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
+                "suggested_area": self._channel.room_name,
+                "via_device": (DOMAIN, self._channel.device_serial),
+            }
+
         return {
             "identifiers": {(DOMAIN, self._channel.device_serial)},
             "name": self._channel.device_name,
-            "manufacturer": "ABB busch-jaeger",
+            "manufacturer": "ABB Busch-Jaeger",
             "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.room_name,
+            "suggested_area": self._channel.device.room_name,
             "via_device": (DOMAIN, self._sysap_serial_number),
         }
 

--- a/custom_components/abbfreeathome_ci/sensor.py
+++ b/custom_components/abbfreeathome_ci/sensor.py
@@ -24,7 +24,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN, MANUFACTURER
 
 SENSOR_DESCRIPTIONS = {
     "BrightnessSensor": {
@@ -166,8 +166,9 @@ class FreeAtHomeSensorEntity(SensorEntity):
                     )
                 },
                 name=self._channel.channel_name,
-                manufacturer="ABB Busch-Jaeger",
+                manufacturer=MANUFACTURER,
                 serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                hw_version=f"{self._channel.device.device_id} (sub)",
                 suggested_area=self._channel.room_name,
                 via_device=(DOMAIN, self._channel.device_serial),
             )

--- a/custom_components/abbfreeathome_ci/sensor.py
+++ b/custom_components/abbfreeathome_ci/sensor.py
@@ -158,28 +158,21 @@ class FreeAtHomeSensorEntity(SensorEntity):
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
         if self._create_subdevices and self._channel.device.is_multi_device:
-            return {
-                "identifiers": {
+            return DeviceInfo(
+                identifiers={
                     (
                         DOMAIN,
                         f"{self._channel.device_serial}_{self._channel.channel_id}",
                     )
                 },
-                "name": self._channel.channel_name,
-                "manufacturer": "ABB Busch-Jaeger",
-                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
-                "suggested_area": self._channel.room_name,
-                "via_device": (DOMAIN, self._channel.device_serial),
-            }
+                name=self._channel.channel_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                suggested_area=self._channel.room_name,
+                via_device=(DOMAIN, self._channel.device_serial),
+            )
 
-        return {
-            "identifiers": {(DOMAIN, self._channel.device_serial)},
-            "name": self._channel.device_name,
-            "manufacturer": "ABB Busch-Jaeger",
-            "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.device.room_name,
-            "via_device": (DOMAIN, self._sysap_serial_number),
-        }
+        return DeviceInfo(identifiers={(DOMAIN, self._channel.device_serial)})
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/abbfreeathome_ci/sensor.py
+++ b/custom_components/abbfreeathome_ci/sensor.py
@@ -21,7 +21,6 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import LIGHT_LUX, UnitOfSpeed, UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -107,9 +106,7 @@ async def async_setup_entry(
                 entity_description_kwargs={"key": key}
                 | description.get("entity_description_kwargs"),
                 sysap_serial_number=entry.data[CONF_SERIAL],
-                hass=hass,
                 create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
-                config_entry_id=entry.entry_id,
             )
             for channel in free_at_home.get_channels_by_class(
                 channel_class=description.get("channel_class")
@@ -129,9 +126,7 @@ class FreeAtHomeSensorEntity(SensorEntity):
         value_attribute: str,
         entity_description_kwargs: dict[str:Any],
         sysap_serial_number: str,
-        hass: HomeAssistant,
         create_subdevices: bool,
-        config_entry_id: str,
     ) -> None:
         """Initialize the sensor."""
         super().__init__()
@@ -146,18 +141,6 @@ class FreeAtHomeSensorEntity(SensorEntity):
             translation_placeholders={"channel_id": channel.channel_id},
             **entity_description_kwargs,
         )
-
-        if self._create_subdevices and self._channel.device.floor is None:
-            device_registry = dr.async_get(hass)
-            device_registry.async_get_or_create(
-                config_entry_id=config_entry_id,
-                identifiers={(DOMAIN, self._channel.device_serial)},
-                name=self._channel.device_name,
-                manufacturer="ABB Busch-Jaeger",
-                serial_number=self._channel.device_serial,
-                suggested_area=None,
-                via_device=(DOMAIN, self._sysap_serial_number),
-            )
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
@@ -174,7 +157,7 @@ class FreeAtHomeSensorEntity(SensorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
-        if self._create_subdevices and self._channel.device.floor is None:
+        if self._create_subdevices and self._channel.device.is_multi_device:
             return {
                 "identifiers": {
                     (

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -9,7 +9,8 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
-          "include_virtual_devices": "Include virtual devices?"
+          "include_virtual_devices": "Include virtual devices?",
+          "create_subdevices": "Create Sub-Devices for each independent channel?"
         }
       },
       "zeroconf_confirm": {
@@ -20,7 +21,8 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
-          "include_virtual_devices": "Include virtual devices?"
+          "include_virtual_devices": "Include virtual devices?",
+          "create_subdevices": "Create Sub-Devices for each independent channel?"
         }
       },
       "reconfigure": {
@@ -30,7 +32,8 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
-          "include_virtual_devices": "Include virtual devices?"
+          "include_virtual_devices": "Include virtual devices?",
+          "create_subdevices": "Create Sub-Devices for each independent channel?"
         }
       }
     },

--- a/custom_components/abbfreeathome_ci/switch.py
+++ b/custom_components/abbfreeathome_ci/switch.py
@@ -25,10 +25,11 @@ from homeassistant.components.switch import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
 
 SWITCH_DESCRIPTIONS = {
     "DimmingSensorLed": {
@@ -119,6 +120,9 @@ async def async_setup_entry(
                 entity_description_kwargs={"key": key}
                 | description.get("entity_description_kwargs"),
                 sysap_serial_number=entry.data[CONF_SERIAL],
+                hass=hass,
+                create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
+                config_entry_id=entry.entry_id,
             )
             for channel in free_at_home.get_channels_by_class(
                 channel_class=description.get("channel_class")
@@ -143,12 +147,16 @@ class FreeAtHomeSwitchEntity(SwitchEntity):
         value_attribute: str,
         entity_description_kwargs: dict[str:Any],
         sysap_serial_number: str,
+        hass: HomeAssistant,
+        create_subdevices: bool,
+        config_entry_id: str,
     ) -> None:
         """Initialize the sensor."""
         super().__init__()
         self._channel = channel
         self._value_attribute = value_attribute
         self._sysap_serial_number = sysap_serial_number
+        self._create_subdevices = create_subdevices
 
         self.entity_description = SwitchEntityDescription(
             has_entity_name=True,
@@ -156,6 +164,18 @@ class FreeAtHomeSwitchEntity(SwitchEntity):
             translation_placeholders={"channel_id": channel.channel_id},
             **entity_description_kwargs,
         )
+
+        if self._create_subdevices and self._channel.device.floor is None:
+            device_registry = dr.async_get(hass)
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry_id,
+                identifiers={(DOMAIN, self._channel.device_serial)},
+                name=self._channel.device_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=self._channel.device_serial,
+                suggested_area=None,
+                via_device=(DOMAIN, self._sysap_serial_number),
+            )
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
@@ -172,12 +192,27 @@ class FreeAtHomeSwitchEntity(SwitchEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
+        if self._create_subdevices and self._channel.device.floor is None:
+            return {
+                "identifiers": {
+                    (
+                        DOMAIN,
+                        f"{self._channel.device_serial}_{self._channel.channel_id}",
+                    )
+                },
+                "name": self._channel.channel_name,
+                "manufacturer": "ABB Busch-Jaeger",
+                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
+                "suggested_area": self._channel.room_name,
+                "via_device": (DOMAIN, self._channel.device_serial),
+            }
+
         return {
             "identifiers": {(DOMAIN, self._channel.device_serial)},
             "name": self._channel.device_name,
-            "manufacturer": "ABB busch-jaeger",
+            "manufacturer": "ABB Busch-Jaeger",
             "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.room_name,
+            "suggested_area": self._channel.device.room_name,
             "via_device": (DOMAIN, self._sysap_serial_number),
         }
 

--- a/custom_components/abbfreeathome_ci/switch.py
+++ b/custom_components/abbfreeathome_ci/switch.py
@@ -28,7 +28,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN, MANUFACTURER
 
 SWITCH_DESCRIPTIONS = {
     "DimmingSensorLed": {
@@ -184,8 +184,9 @@ class FreeAtHomeSwitchEntity(SwitchEntity):
                     )
                 },
                 name=self._channel.channel_name,
-                manufacturer="ABB Busch-Jaeger",
+                manufacturer=MANUFACTURER,
                 serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                hw_version=f"{self._channel.device.device_id} (sub)",
                 suggested_area=self._channel.room_name,
                 via_device=(DOMAIN, self._channel.device_serial),
             )

--- a/custom_components/abbfreeathome_ci/switch.py
+++ b/custom_components/abbfreeathome_ci/switch.py
@@ -25,7 +25,6 @@ from homeassistant.components.switch import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -120,9 +119,7 @@ async def async_setup_entry(
                 entity_description_kwargs={"key": key}
                 | description.get("entity_description_kwargs"),
                 sysap_serial_number=entry.data[CONF_SERIAL],
-                hass=hass,
                 create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
-                config_entry_id=entry.entry_id,
             )
             for channel in free_at_home.get_channels_by_class(
                 channel_class=description.get("channel_class")
@@ -147,9 +144,7 @@ class FreeAtHomeSwitchEntity(SwitchEntity):
         value_attribute: str,
         entity_description_kwargs: dict[str:Any],
         sysap_serial_number: str,
-        hass: HomeAssistant,
         create_subdevices: bool,
-        config_entry_id: str,
     ) -> None:
         """Initialize the sensor."""
         super().__init__()
@@ -164,18 +159,6 @@ class FreeAtHomeSwitchEntity(SwitchEntity):
             translation_placeholders={"channel_id": channel.channel_id},
             **entity_description_kwargs,
         )
-
-        if self._create_subdevices and self._channel.device.floor is None:
-            device_registry = dr.async_get(hass)
-            device_registry.async_get_or_create(
-                config_entry_id=config_entry_id,
-                identifiers={(DOMAIN, self._channel.device_serial)},
-                name=self._channel.device_name,
-                manufacturer="ABB Busch-Jaeger",
-                serial_number=self._channel.device_serial,
-                suggested_area=None,
-                via_device=(DOMAIN, self._sysap_serial_number),
-            )
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
@@ -192,7 +175,7 @@ class FreeAtHomeSwitchEntity(SwitchEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
-        if self._create_subdevices and self._channel.device.floor is None:
+        if self._create_subdevices and self._channel.device.is_multi_device:
             return {
                 "identifiers": {
                     (

--- a/custom_components/abbfreeathome_ci/switch.py
+++ b/custom_components/abbfreeathome_ci/switch.py
@@ -176,28 +176,21 @@ class FreeAtHomeSwitchEntity(SwitchEntity):
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
         if self._create_subdevices and self._channel.device.is_multi_device:
-            return {
-                "identifiers": {
+            return DeviceInfo(
+                identifiers={
                     (
                         DOMAIN,
                         f"{self._channel.device_serial}_{self._channel.channel_id}",
                     )
                 },
-                "name": self._channel.channel_name,
-                "manufacturer": "ABB Busch-Jaeger",
-                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
-                "suggested_area": self._channel.room_name,
-                "via_device": (DOMAIN, self._channel.device_serial),
-            }
+                name=self._channel.channel_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                suggested_area=self._channel.room_name,
+                via_device=(DOMAIN, self._channel.device_serial),
+            )
 
-        return {
-            "identifiers": {(DOMAIN, self._channel.device_serial)},
-            "name": self._channel.device_name,
-            "manufacturer": "ABB Busch-Jaeger",
-            "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.device.room_name,
-            "via_device": (DOMAIN, self._sysap_serial_number),
-        }
+        return DeviceInfo(identifiers={(DOMAIN, self._channel.device_serial)})
 
     @property
     def translation_key(self):

--- a/custom_components/abbfreeathome_ci/translations/de.json
+++ b/custom_components/abbfreeathome_ci/translations/de.json
@@ -9,7 +9,8 @@
           "username": "Benutzername",
           "password": "Passwort",
           "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
-          "include_virtual_devices": "Virtuelle Geräte einschließen?"
+          "include_virtual_devices": "Virtuelle Geräte einschließen?",
+          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?"
         }
       },
       "zeroconf_confirm": {
@@ -20,7 +21,8 @@
           "username": "Benutzername",
           "password": "Passwort",
           "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
-          "include_virtual_devices": "Virtuelle Geräte einschließen?"
+          "include_virtual_devices": "Virtuelle Geräte einschließen?",
+          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?"
         }
       },
       "reconfigure": {
@@ -30,7 +32,8 @@
           "username": "Benutzername",
           "password": "Passwort",
           "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
-          "include_virtual_devices": "Virtuelle Geräte einschließen?"
+          "include_virtual_devices": "Virtuelle Geräte einschließen?",
+          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?"
         }
       }
     },

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -18,6 +18,7 @@
         "data": {
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
           "include_virtual_devices": "Include virtual devices?",
+          "create_subdevices": "Create Sub-Devices for each independent channel?",
           "password": "Password",
           "username": "Username"
         },
@@ -29,6 +30,7 @@
           "host": "Host",
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
           "include_virtual_devices": "Include virtual devices?",
+          "create_subdevices": "Create Sub-Devices for each independent channel?",
           "password": "Password",
           "username": "Username"
         },
@@ -40,6 +42,7 @@
           "host": "Host",
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
           "include_virtual_devices": "Include virtual devices?",
+          "create_subdevices": "Create Sub-Devices for each independent channel?",
           "password": "Password",
           "username": "Username"
         },

--- a/custom_components/abbfreeathome_ci/valve.py
+++ b/custom_components/abbfreeathome_ci/valve.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN, MANUFACTURER
 
 
 async def async_setup_entry(
@@ -86,8 +86,9 @@ class FreeAtHomeValveEntity(ValveEntity):
                     )
                 },
                 name=self._channel.channel_name,
-                manufacturer="ABB Busch-Jaeger",
+                manufacturer=MANUFACTURER,
                 serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                hw_version=f"{self._channel.device.device_id} (sub)",
                 suggested_area=self._channel.room_name,
                 via_device=(DOMAIN, self._channel.device_serial),
             )

--- a/custom_components/abbfreeathome_ci/valve.py
+++ b/custom_components/abbfreeathome_ci/valve.py
@@ -78,28 +78,21 @@ class FreeAtHomeValveEntity(ValveEntity):
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
         if self._create_subdevices and self._channel.device.is_multi_device:
-            return {
-                "identifiers": {
+            return DeviceInfo(
+                identifiers={
                     (
                         DOMAIN,
                         f"{self._channel.device_serial}_{self._channel.channel_id}",
                     )
                 },
-                "name": self._channel.channel_name,
-                "manufacturer": "ABB Busch-Jaeger",
-                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
-                "suggested_area": self._channel.room_name,
-                "via_device": (DOMAIN, self._channel.device_serial),
-            }
+                name=self._channel.channel_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=f"{self._channel.device_serial}_{self._channel.channel_id}",
+                suggested_area=self._channel.room_name,
+                via_device=(DOMAIN, self._channel.device_serial),
+            )
 
-        return {
-            "identifiers": {(DOMAIN, self._channel.device_serial)},
-            "name": self._channel.device_name,
-            "manufacturer": "ABB Busch-Jaeger",
-            "serial_number": self._channel.device_serial,
-            "suggested_area": self._channel.device.room_name,
-            "via_device": (DOMAIN, self._sysap_serial_number),
-        }
+        return DeviceInfo(identifiers={(DOMAIN, self._channel.device_serial)})
 
     @property
     def current_valve_position(self) -> int | None:

--- a/custom_components/abbfreeathome_ci/valve.py
+++ b/custom_components/abbfreeathome_ci/valve.py
@@ -13,7 +13,6 @@ from homeassistant.components.valve import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -32,9 +31,7 @@ async def async_setup_entry(
         FreeAtHomeValveEntity(
             channel,
             sysap_serial_number=entry.data[CONF_SERIAL],
-            hass=hass,
             create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
-            config_entry_id=entry.entry_id,
         )
         for channel in free_at_home.get_channels_by_class(channel_class=HeatingActuator)
     )
@@ -49,9 +46,7 @@ class FreeAtHomeValveEntity(ValveEntity):
         self,
         channel: HeatingActuator,
         sysap_serial_number: str,
-        hass: HomeAssistant,
         create_subdevices: bool,
-        config_entry_id: str,
     ) -> None:
         """Initialize the valve."""
         super().__init__()
@@ -66,18 +61,6 @@ class FreeAtHomeValveEntity(ValveEntity):
             name=channel.channel_name,
             reports_position=True,
         )
-
-        if self._create_subdevices and self._channel.device.floor is None:
-            device_registry = dr.async_get(hass)
-            device_registry.async_get_or_create(
-                config_entry_id=config_entry_id,
-                identifiers={(DOMAIN, self._channel.device_serial)},
-                name=self._channel.device_name,
-                manufacturer="ABB Busch-Jaeger",
-                serial_number=self._channel.device_serial,
-                suggested_area=None,
-                via_device=(DOMAIN, self._sysap_serial_number),
-            )
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
@@ -94,7 +77,7 @@ class FreeAtHomeValveEntity(ValveEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
-        if self._create_subdevices and self._channel.device.floor is None:
+        if self._create_subdevices and self._channel.device.is_multi_device:
             return {
                 "identifiers": {
                     (

--- a/custom_components/abbfreeathome_ci/valve.py
+++ b/custom_components/abbfreeathome_ci/valve.py
@@ -13,10 +13,11 @@ from homeassistant.components.valve import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_SERIAL, DOMAIN
+from .const import CONF_CREATE_SUBDEVICES, CONF_SERIAL, DOMAIN
 
 
 async def async_setup_entry(
@@ -28,8 +29,14 @@ async def async_setup_entry(
     free_at_home: FreeAtHome = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities(
-        FreeAtHomeValveEntity(valve, sysap_serial_number=entry.data[CONF_SERIAL])
-        for valve in free_at_home.get_channels_by_class(channel_class=HeatingActuator)
+        FreeAtHomeValveEntity(
+            channel,
+            sysap_serial_number=entry.data[CONF_SERIAL],
+            hass=hass,
+            create_subdevices=entry.data[CONF_CREATE_SUBDEVICES],
+            config_entry_id=entry.entry_id,
+        )
+        for channel in free_at_home.get_channels_by_class(channel_class=HeatingActuator)
     )
 
 
@@ -38,53 +45,88 @@ class FreeAtHomeValveEntity(ValveEntity):
 
     _attr_should_poll: bool = False
 
-    def __init__(self, valve: HeatingActuator, sysap_serial_number: str) -> None:
+    def __init__(
+        self,
+        channel: HeatingActuator,
+        sysap_serial_number: str,
+        hass: HomeAssistant,
+        create_subdevices: bool,
+        config_entry_id: str,
+    ) -> None:
         """Initialize the valve."""
         super().__init__()
-        self._valve = valve
+        self._channel = channel
         self._sysap_serial_number = sysap_serial_number
+        self._create_subdevices = create_subdevices
 
         self.entity_description = ValveEntityDescription(
             key="HeatingActuatorValve",
             device_class=ValveDeviceClass.WATER,
             entity_registry_enabled_default=False,
-            name=valve.channel_name,
+            name=channel.channel_name,
             reports_position=True,
         )
 
+        if self._create_subdevices and self._channel.device.floor is None:
+            device_registry = dr.async_get(hass)
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry_id,
+                identifiers={(DOMAIN, self._channel.device_serial)},
+                name=self._channel.device_name,
+                manufacturer="ABB Busch-Jaeger",
+                serial_number=self._channel.device_serial,
+                suggested_area=None,
+                via_device=(DOMAIN, self._sysap_serial_number),
+            )
+
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
-        self._valve.register_callback(
+        self._channel.register_callback(
             callback_attribute="position", callback=self.async_write_ha_state
         )
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity being removed from hass."""
-        self._valve.remove_callback(
+        self._channel.remove_callback(
             callback_attribute="position", callback=self.async_write_ha_state
         )
 
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
+        if self._create_subdevices and self._channel.device.floor is None:
+            return {
+                "identifiers": {
+                    (
+                        DOMAIN,
+                        f"{self._channel.device_serial}_{self._channel.channel_id}",
+                    )
+                },
+                "name": self._channel.channel_name,
+                "manufacturer": "ABB Busch-Jaeger",
+                "serial_number": f"{self._channel.device_serial}_{self._channel.channel_id}",
+                "suggested_area": self._channel.room_name,
+                "via_device": (DOMAIN, self._channel.device_serial),
+            }
+
         return {
-            "identifiers": {(DOMAIN, self._valve.device_serial)},
-            "name": self._valve.device_name,
-            "manufacturer": "ABB busch-jaeger",
-            "serial_number": self._valve.device_serial,
-            "suggested_area": self._valve.room_name,
+            "identifiers": {(DOMAIN, self._channel.device_serial)},
+            "name": self._channel.device_name,
+            "manufacturer": "ABB Busch-Jaeger",
+            "serial_number": self._channel.device_serial,
+            "suggested_area": self._channel.device.room_name,
             "via_device": (DOMAIN, self._sysap_serial_number),
         }
 
     @property
     def current_valve_position(self) -> int | None:
         """Return position of the valve."""
-        return self._valve.position
+        return self._channel.position
 
     @property
     def unique_id(self) -> str | None:
         """Return a unique ID."""
-        return f"{self._valve.device_serial}_{self._valve.channel_id}_valve"
+        return f"{self._channel.device_serial}_{self._channel.channel_id}_valve"
 
     @property
     def supported_features(self) -> int | None:
@@ -93,8 +135,8 @@ class FreeAtHomeValveEntity(ValveEntity):
 
     async def async_set_valve_position(self, position: int) -> None:
         """Move the valve to a specific position."""
-        await self._valve.set_position(position)
+        await self._channel.set_position(position)
 
     async def async_update(self, **kwargs: Any) -> None:
         """Update the valve state."""
-        await self._valve.refresh_state()
+        await self._channel.refresh_state()


### PR DESCRIPTION
Closes #157 

This implements the possibilities to have sub-devices for each "multi-device" in F@H, which can be placed independently on the floorplan.

This can increase the device-count drastically. In my case it increased from 86 to 181 devices.

The default is false (also for existing installation), so the change needs to be specific wanted by the user.

Additionally, what I saw during my tests: If you switch on this feature, the existing multi-device will preserve the original set area (this needs to be manually removed), only with a fresh installation the physical (multi) device will not have an area assigned.

I also encountered (once again) a small bug from ABB:
E.g. a virtual switch and a virtual energy meter are correctly displayed in HA as one device, but a virtual binary sensor does not has a floor and a room assigned on device level, only on channel level. This means that you will have for a virtual binary sensor a device within a device.