### PR TITLE
Implement Welcome IP Mute Actuator/Sensor

### DIFF
--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -278,6 +278,9 @@
       },
       "virtual_wind_sensor": {
         "name": "Virtual Wind Alarm"
+      },
+      "welcome_ip_mute_actuator": {
+        "name": "Mute"
       }
     }
   },

--- a/custom_components/abbfreeathome_ci/switch.py
+++ b/custom_components/abbfreeathome_ci/switch.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from abbfreeathome import FreeAtHome
-from abbfreeathome.channels.switch_actuator import SimpleSwitchActuator, SwitchActuator
+from abbfreeathome.channels.switch_actuator import SwitchActuator, WelcomeIPMuteActuator
 from abbfreeathome.channels.switch_sensor import DimmingSensor, SwitchSensor
 from abbfreeathome.channels.virtual.virtual_brightness_sensor import (
     VirtualBrightnessSensor,
@@ -101,7 +101,7 @@ SWITCH_DESCRIPTIONS = {
         },
     },
     "WelcomeIPMuteActuator": {
-        "channel_class": SimpleSwitchActuator,
+        "channel_class": WelcomeIPMuteActuator,
         "value_attribute": "state",
         "entity_description_kwargs": {
             "device_class": SwitchDeviceClass.SWITCH,
@@ -148,7 +148,8 @@ class FreeAtHomeSwitchEntity(SwitchEntity):
         | SwitchSensor
         | VirtualBrightnessSensor
         | VirtualSwitchActuator
-        | VirtualWindowDoorSensor,
+        | VirtualWindowDoorSensor
+        | WelcomeIPMuteActuator,
         value_attribute: str,
         entity_description_kwargs: dict[str:Any],
         sysap_serial_number: str,

--- a/custom_components/abbfreeathome_ci/switch.py
+++ b/custom_components/abbfreeathome_ci/switch.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from abbfreeathome import FreeAtHome
-from abbfreeathome.channels.switch_actuator import SwitchActuator, WelcomeIPMuteActuator
+from abbfreeathome.channels.switch_actuator import SimpleSwitchActuator, SwitchActuator
 from abbfreeathome.channels.switch_sensor import DimmingSensor, SwitchSensor
 from abbfreeathome.channels.virtual.virtual_brightness_sensor import (
     VirtualBrightnessSensor,
@@ -101,7 +101,7 @@ SWITCH_DESCRIPTIONS = {
         },
     },
     "WelcomeIPMuteActuator": {
-        "channel_class": WelcomeIPMuteActuator,
+        "channel_class": SimpleSwitchActuator,
         "value_attribute": "state",
         "entity_description_kwargs": {
             "device_class": SwitchDeviceClass.SWITCH,

--- a/custom_components/abbfreeathome_ci/switch.py
+++ b/custom_components/abbfreeathome_ci/switch.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from abbfreeathome import FreeAtHome
-from abbfreeathome.channels.switch_actuator import SwitchActuator
+from abbfreeathome.channels.switch_actuator import SwitchActuator, WelcomeIPMuteActuator
 from abbfreeathome.channels.switch_sensor import DimmingSensor, SwitchSensor
 from abbfreeathome.channels.virtual.virtual_brightness_sensor import (
     VirtualBrightnessSensor,
@@ -98,6 +98,14 @@ SWITCH_DESCRIPTIONS = {
         "entity_description_kwargs": {
             "device_class": SwitchDeviceClass.SWITCH,
             "translation_key": "virtual_temperature_sensor",
+        },
+    },
+    "WelcomeIPMuteActuator": {
+        "channel_class": WelcomeIPMuteActuator,
+        "value_attribute": "state",
+        "entity_description_kwargs": {
+            "device_class": SwitchDeviceClass.SWITCH,
+            "translation_key": "welcome_ip_mute_actuator",
         },
     },
 }

--- a/custom_components/abbfreeathome_ci/translations/de.json
+++ b/custom_components/abbfreeathome_ci/translations/de.json
@@ -278,6 +278,9 @@
       },
       "virtual_wind_sensor": {
         "name": "Virtueller Windalarm"
+      },
+      "welcome_ip_mute_actuator": {
+        "name": "Stummschaltung"
       }
     }
   },

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -278,6 +278,9 @@
       },
       "virtual_wind_sensor": {
         "name": "Virtual Wind Alarm"
+      },
+      "welcome_ip_mute_actuator": {
+        "name": "Mute"
       }
     }
   },


### PR DESCRIPTION
This implements support Welcome IP Mute Actuator/Sensor.

I don't fully understand the behavior of the sensor, but as it was requested ...

The switch correctly activates or deactivates the Mute-function of the Panel. The changes are also reflected with the F@H app.

But if the mute-function on the panel is used, then the switch stays as it is, but the event is fired.