### PR TITLE
Support for BlockableMotionDetector

### DIFF
--- a/custom_components/abbfreeathome_ci/binary_sensor.py
+++ b/custom_components/abbfreeathome_ci/binary_sensor.py
@@ -5,7 +5,10 @@ from typing import Any
 from abbfreeathome import FreeAtHome
 from abbfreeathome.channels.brightness_sensor import BrightnessSensor
 from abbfreeathome.channels.carbon_monoxide_sensor import CarbonMonoxideSensor
-from abbfreeathome.channels.movement_detector import MovementDetector
+from abbfreeathome.channels.movement_detector import (
+    BlockableMovementDetector,
+    MovementDetector,
+)
 from abbfreeathome.channels.rain_sensor import RainSensor
 from abbfreeathome.channels.smoke_detector import SmokeDetector
 from abbfreeathome.channels.temperature_sensor import TemperatureSensor
@@ -35,6 +38,14 @@ SENSOR_DESCRIPTIONS = {
     },
     "MovementDetectorMotion": {
         "channel_class": MovementDetector,
+        "value_attribute": "state",
+        "entity_description_kwargs": {
+            "device_class": BinarySensorDeviceClass.MOTION,
+            "translation_key": "movement_detector_motion",
+        },
+    },
+    "BlockableMovementDetectorMotion": {
+        "channel_class": BlockableMovementDetector,
         "value_attribute": "state",
         "entity_description_kwargs": {
             "device_class": BinarySensorDeviceClass.MOTION,

--- a/custom_components/abbfreeathome_ci/sensor.py
+++ b/custom_components/abbfreeathome_ci/sensor.py
@@ -4,7 +4,10 @@ from typing import Any
 
 from abbfreeathome import FreeAtHome
 from abbfreeathome.channels.brightness_sensor import BrightnessSensor
-from abbfreeathome.channels.movement_detector import MovementDetector
+from abbfreeathome.channels.movement_detector import (
+    BlockableMovementDetector,
+    MovementDetector,
+)
 from abbfreeathome.channels.temperature_sensor import TemperatureSensor
 from abbfreeathome.channels.wind_sensor import WindSensor
 from abbfreeathome.channels.window_door_sensor import (
@@ -39,6 +42,16 @@ SENSOR_DESCRIPTIONS = {
     },
     "MovementDetectorBrightness": {
         "channel_class": MovementDetector,
+        "value_attribute": "brightness",
+        "entity_description_kwargs": {
+            "device_class": SensorDeviceClass.ILLUMINANCE,
+            "native_unit_of_measurement": LIGHT_LUX,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "translation_key": "movement_detector_brightness",
+        },
+    },
+    "BlockableMovementDetectorBrightness": {
+        "channel_class": BlockableMovementDetector,
         "value_attribute": "brightness",
         "entity_description_kwargs": {
             "device_class": SensorDeviceClass.ILLUMINANCE,

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -264,6 +264,9 @@
       }
     },
     "switch": {
+      "movement_detector_block": {
+        "name": "Block Movement Detection"
+      },
       "sensor_led": {
         "name": "LED ({channel_id})"
       },

--- a/custom_components/abbfreeathome_ci/switch.py
+++ b/custom_components/abbfreeathome_ci/switch.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from abbfreeathome import FreeAtHome
+from abbfreeathome.channels.movement_detector import BlockableMovementDetector
 from abbfreeathome.channels.switch_actuator import SwitchActuator
 from abbfreeathome.channels.switch_sensor import DimmingSensor, SwitchSensor
 from abbfreeathome.channels.virtual.virtual_brightness_sensor import (
@@ -98,6 +99,14 @@ SWITCH_DESCRIPTIONS = {
         "entity_description_kwargs": {
             "device_class": SwitchDeviceClass.SWITCH,
             "translation_key": "virtual_temperature_sensor",
+        },
+    },
+    "BlockableMovementDetector": {
+        "channel_class": BlockableMovementDetector,
+        "value_attribute": "blocked",
+        "entity_description_kwargs": {
+            "device_class": SwitchDeviceClass.SWITCH,
+            "translation_key": "movement_detector_block",
         },
     },
 }

--- a/custom_components/abbfreeathome_ci/translations/de.json
+++ b/custom_components/abbfreeathome_ci/translations/de.json
@@ -264,6 +264,9 @@
       }
     },
     "switch": {
+      "movement_detector_block": {
+        "name": "Sperre Bewegungsmelder"
+      },
       "sensor_led": {
         "name": "LED ({channel_id})"
       },

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -264,6 +264,9 @@
       }
     },
     "switch": {
+      "movement_detector_block": {
+        "name": "Block Movement Detection"
+      },
       "sensor_led": {
         "name": "LED ({channel_id})"
       },


### PR DESCRIPTION
This PR is based on the [PR #216](https://github.com/kingsleyadam/local-abbfreeathome/pull/216) of local-abbfreeathome and adds support for the new BlockableMotionDetector. Both a binary sensor for the motion detection and a switch for blocking the motion detection have been added.

Please note that at least version 3.1.0 of local-abbfreeathome is needed. I did not update the manifest.json because I wasn't sure if I am allowed to change it.