### PR TITLE
Adjust how translation key is returned for binary sensor, switch

### DIFF
--- a/custom_components/abbfreeathome_ci/binary_sensor.py
+++ b/custom_components/abbfreeathome_ci/binary_sensor.py
@@ -213,9 +213,7 @@ class FreeAtHomeBinarySensorEntity(BinarySensorEntity):
         if hasattr(self, "entity_description"):
             _translation_key = self.entity_description.translation_key
 
-        if self._channel.channel_name == self._channel.device_name:
-            return _translation_key
-        return None
+        return _translation_key
 
     @property
     def unique_id(self) -> str | None:

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -10,7 +10,7 @@
   "loggers": ["abbfreeathome"],
   "requirements": ["local-abbfreeathome==3.1.1"],
   "ssdp": [],
-  "version": "1.8.0b1",
+  "version": "1.8.0b2",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/custom_components/abbfreeathome_ci/switch.py
+++ b/custom_components/abbfreeathome_ci/switch.py
@@ -243,9 +243,7 @@ class FreeAtHomeSwitchEntity(SwitchEntity):
         if hasattr(self, "entity_description"):
             _translation_key = self.entity_description.translation_key
 
-        if self._channel.channel_name == self._channel.device_name:
-            return _translation_key
-        return None
+        return _translation_key
 
     @property
     def is_on(self) -> bool | None:


### PR DESCRIPTION
This PR adjusts how the translation key is provided for the binary sensor and switch.

- If a translation_key is provided for the entity it's expected that we'll always use the translation for the name of the object. If there is not translation_key then Home Assistant will use the entity name instead.