### PR TITLE
Add SSL Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,17 @@ The config setup will include some options to help configure the integration.
 - **Include channels NOT on the free@home floorplan?**: False
 - **Include virtual devices?**: False
 - **Create Sub-Devices for each independent channel?**: False
+- **SSL Certificate File Path**: (optional)
 
-> Note: Support for SSL is not provided yet. For a valid SSL connection a cert pulled from the SysAP must be provided, research to be done to know if Home Assistant supports such a scenario.
+#### SSL Support
+
+The integration now supports SSL connections to the ABB-free@home SysAP. To enable SSL with certificate verification:
+
+1. Provide the path to your SSL certificate file in the "SSL Certificate File Path" field
+2. When a certificate path is provided, the integration will enable SSL verification
+3. When no certificate path is provided, SSL verification is disabled (default behavior)
+
+This allows you to securely connect to your SysAP when using HTTPS URLs while providing the necessary certificate for verification.
 
 #### SysAP Discovery
 
@@ -134,7 +143,35 @@ abbfreeathome_ci:
   include_orphan_channels: false
   include_virtual_devices: false
   include_subdevices: false
+  ssl_cert_path: /path/to/certificate.pem # optional
 ```
+
+**SSL Configuration Examples:**
+
+**With SSL certificate verification:**
+
+```yaml
+abbfreeathome_ci:
+  host: https://<hostname or ip address>
+  username: installer
+  password: <password>
+  ssl_cert_path: /config/ssl/sysap_cert.pem
+  # SSL verification enabled automatically when certificate path is provided
+```
+
+**HTTPS without SSL certificate (verification disabled with warning):**
+
+```yaml
+abbfreeathome_ci:
+  host: https://<hostname or ip address>
+  username: installer
+  password: <password>
+  # No ssl_cert_path means verification is disabled (generates warning)
+```
+
+> **Security Note:** When using HTTPS without providing an SSL certificate path, SSL certificate verification is automatically disabled. This is because ABB SysAP devices typically use self-signed certificates. A warning will be logged to indicate this security consideration.
+
+> **Certificate Usage:** When an SSL certificate path is provided, verification is automatically enabled using that certificate file for validation.
 
 Each time Home Assistant is loaded, the `configuration.yaml` entry for `abbfreeathome_ci` will be checked, verified, and updated accordingly. This means that if you want to update your configuration, simply modify the `configuration.yaml` file and restart Home Assistant.
 
@@ -169,14 +206,14 @@ triggers:
   - trigger: state
     entity_id:
       - event.study_area_rocker_switch_event
-    to: "Off"
+    to: 'Off'
     attribute: event_type
     id: study_area_event_off
   - trigger: state
     entity_id:
       - event.study_area_rocker_switch_event
     attribute: event_type
-    to: "On"
+    to: 'On'
     id: study_area_event_on
 conditions: []
 actions:

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ The config setup will include some options to help configure the integration.
 | Include channels NOT on the free@home floorplan? | Whether to include channels that are not located on the free@home floorplan.                                                             |
 | Include virtual devices?                         | Whether to include virtual devices or not.                                                                                               |
 | Create Sub-Devices for each independent channel? | Wether to create sub-devices for each channel of a physical device, which can be placed independently on the free@home floorplan or not. |
+| Verify SSL Certificate                           | Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate.                            |
+| SSL Certificate File Path                        | Path to SSL certificate file to verify HTTPS/SSL connections.                                                                            |
 
 ###### Example
 
@@ -109,17 +111,25 @@ The config setup will include some options to help configure the integration.
 - **Include channels NOT on the free@home floorplan?**: False
 - **Include virtual devices?**: False
 - **Create Sub-Devices for each independent channel?**: False
+- **Verify SSL Certificate**: False
 - **SSL Certificate File Path**: (optional)
 
 #### SSL Support
 
-The integration now supports SSL connections to the ABB-free@home SysAP. To enable SSL with certificate verification:
+The integration supports SSL connections to the ABB-free@home SysAP. When setting up the intregration, if you provide `https` schema in the `Hostname` field you will be prompted with some SSL options. You can disable SSL verification completely by unhecking `Verify SSL Certificate`. You will still have an SSL connection, but the endpoint/certificated will not be verified and the connection may be insecure. To enable SSL with certificate verification:
 
-1. Provide the path to your SSL certificate file in the "SSL Certificate File Path" field
-2. When a certificate path is provided, the integration will enable SSL verification
-3. When no certificate path is provided, SSL verification is disabled (default behavior)
+1. Set Verify SSL Certificate to true
+2. Provide the path to your SSL certificate file in the "SSL Certificate File Path" field
 
 This allows you to securely connect to your SysAP when using HTTPS URLs while providing the necessary certificate for verification.
+
+##### Fetch SSL Certificate
+
+The certificate required for SSL verification is provided by the SysAP.
+
+- Navigate to your SysAP -> Settings --> free@home - Settings --> Local API
+- Under `Connection` you'll have an option to `Download Certificate`
+- Save the certificate to your Home Assistant server to be used by the integration for SSL verification
 
 #### SysAP Discovery
 
@@ -157,7 +167,7 @@ abbfreeathome_ci:
   username: installer
   password: <password>
   ssl_cert_path: /config/ssl/sysap_cert.pem
-  # SSL verification enabled automatically when certificate path is provided
+  verify_ssl: true
 ```
 
 **HTTPS without SSL certificate (verification disabled with warning):**
@@ -167,12 +177,8 @@ abbfreeathome_ci:
   host: https://<hostname or ip address>
   username: installer
   password: <password>
-  # No ssl_cert_path means verification is disabled (generates warning)
+  verify_ssl: false
 ```
-
-> **Security Note:** When using HTTPS without providing an SSL certificate path, SSL certificate verification is automatically disabled. This is because ABB SysAP devices typically use self-signed certificates. A warning will be logged to indicate this security consideration.
-
-> **Certificate Usage:** When an SSL certificate path is provided, verification is automatically enabled using that certificate file for validation.
 
 Each time Home Assistant is loaded, the `configuration.yaml` entry for `abbfreeathome_ci` will be checked, verified, and updated accordingly. This means that if you want to update your configuration, simply modify the `configuration.yaml` file and restart Home Assistant.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The config setup will include some options to help configure the integration.
 
 #### SSL Support
 
-The integration supports SSL connections to the ABB-free@home SysAP. When setting up the intregration, if you provide `https` schema in the `Hostname` field you will be prompted with some SSL options. You can disable SSL verification completely by unhecking `Verify SSL Certificate`. You will still have an SSL connection, but the endpoint/certificated will not be verified and the connection may be insecure. To enable SSL with certificate verification:
+The integration supports SSL connections to the ABB-free@home SysAP. When setting up the intregration, if you provide `https` schema in the `Hostname` field you will be prompted with some SSL options. You can disable SSL verification completely by unhecking `Verify SSL Certificate`. You will still have an SSL connection, but the endpoint/certificate will not be verified and the connection may be insecure. To enable SSL with certificate verification:
 
 1. Set Verify SSL Certificate to true
 2. Provide the path to your SSL certificate file in the "SSL Certificate File Path" field

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The config setup will include some options to help configure the integration.
 | Include virtual devices?                         | Whether to include virtual devices or not.                                                                                               |
 | Create Sub-Devices for each independent channel? | Wether to create sub-devices for each channel of a physical device, which can be placed independently on the free@home floorplan or not. |
 | Verify SSL Certificate                           | Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate.                            |
-| SSL Certificate File Path                        | Path to SSL certificate file to verify HTTPS/SSL connections.                                                                            |
+| SSL Certificate File Path                        | File path to SSL certificate file to verify HTTPS/SSL connections.                                                                       |
 
 ###### Example
 
@@ -153,7 +153,7 @@ abbfreeathome_ci:
   include_orphan_channels: false
   include_virtual_devices: false
   create_subdevices: false
-  ssl_cert_path: config/ssl/sysap.crt # optional
+  ssl_cert_file_path: config/ssl/sysap.crt # optional
   verify_ssl: false # optional
 ```
 
@@ -166,7 +166,7 @@ abbfreeathome_ci:
   host: https://<hostname or ip address>
   username: installer
   password: <password>
-  ssl_cert_path: config/ssl/sysap.crt
+  ssl_cert_file_path: config/ssl/sysap.crt
   verify_ssl: true
 ```
 

--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ abbfreeathome_ci:
   password: <password>
   include_orphan_channels: false
   include_virtual_devices: false
-  include_subdevices: false
+  create_subdevices: false
   ssl_cert_path: /path/to/certificate.pem # optional
+  verify_ssl: false # optional
 ```
 
 **SSL Configuration Examples:**

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The config setup will include some options to help configure the integration.
 - **Include virtual devices?**: False
 - **Create Sub-Devices for each independent channel?**: False
 - **Verify SSL Certificate**: False
-- **SSL Certificate File Path**: (optional)
+- **SSL Certificate File Path**: `config/ssl/sysap.crt`
 
 #### SSL Support
 
@@ -153,7 +153,7 @@ abbfreeathome_ci:
   include_orphan_channels: false
   include_virtual_devices: false
   create_subdevices: false
-  ssl_cert_path: /path/to/certificate.pem # optional
+  ssl_cert_path: config/ssl/sysap.crt # optional
   verify_ssl: false # optional
 ```
 
@@ -166,7 +166,7 @@ abbfreeathome_ci:
   host: https://<hostname or ip address>
   username: installer
   password: <password>
-  ssl_cert_path: /config/ssl/sysap_cert.pem
+  ssl_cert_path: config/ssl/sysap.crt
   verify_ssl: true
 ```
 

--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -34,7 +34,7 @@ from .const import (
     CONF_INCLUDE_ORPHAN_CHANNELS,
     CONF_INCLUDE_VIRTUAL_DEVICES,
     CONF_SERIAL,
-    CONF_SSL_CERT_PATH,
+    CONF_SSL_CERT_FILE_PATH,
     CONF_VERIFY_SSL,
     DOMAIN,
     MANUFACTURER,
@@ -78,7 +78,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_INCLUDE_ORPHAN_CHANNELS, default=False): cv.boolean,
                 vol.Optional(CONF_INCLUDE_VIRTUAL_DEVICES, default=False): cv.boolean,
                 vol.Optional(CONF_CREATE_SUBDEVICES, default=False): cv.boolean,
-                vol.Optional(CONF_SSL_CERT_PATH): cv.string,
+                vol.Optional(CONF_SSL_CERT_FILE_PATH): cv.string,
                 vol.Optional(CONF_VERIFY_SSL): cv.boolean,
             }
         )
@@ -112,7 +112,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _client_session = async_get_clientsession(hass)
 
     # Get SSL certificate configuration
-    _ssl_cert_path = entry.data.get(CONF_SSL_CERT_PATH)
+    _ssl_cert_path = entry.data.get(CONF_SSL_CERT_FILE_PATH)
     _verify_ssl = entry.data.get(CONF_VERIFY_SSL)
 
     # Log SSL configuration warnings
@@ -307,8 +307,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
         if entry.minor_version < 5:
-            if CONF_SSL_CERT_PATH not in new_data:
-                new_data[CONF_SSL_CERT_PATH] = None
+            if CONF_SSL_CERT_FILE_PATH not in new_data:
+                new_data[CONF_SSL_CERT_FILE_PATH] = None
             if CONF_VERIFY_SSL not in new_data:
                 new_data[CONF_VERIFY_SSL] = False
 

--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -112,7 +112,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _client_session = async_get_clientsession(hass)
 
     # Get SSL certificate configuration
-    _ssl_cert_path = entry.data.get(CONF_SSL_CERT_FILE_PATH)
+    _ssl_cert_file_path = entry.data.get(CONF_SSL_CERT_FILE_PATH)
     _verify_ssl = entry.data.get(CONF_VERIFY_SSL)
 
     # Log SSL configuration warnings
@@ -131,7 +131,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         host=entry.data[CONF_HOST],
         client_session=_client_session,
         verify_ssl=_verify_ssl,
-        ssl_cert_ca_file=_ssl_cert_path,
+        ssl_cert_ca_file=_ssl_cert_file_path,
     )
     await _free_at_home_settings.load()
 
@@ -166,7 +166,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             password=entry.data[CONF_PASSWORD],
             client_session=_client_session,
             verify_ssl=_verify_ssl,
-            ssl_cert_ca_file=_ssl_cert_path,
+            ssl_cert_ca_file=_ssl_cert_file_path,
         ),
         interfaces=_interfaces,
         include_orphan_channels=_include_orphan_channels,

--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -119,8 +119,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if _host.startswith("https://"):
         if not _verify_ssl:
             _LOGGER.warning(
-                "ABB-free@home HTTPS connection to SysAP without SSL certificate path - SSL verification will be disabled, "
-                "This connection may not be secure. Consider providing an SSL certificate path for verification"
+                "ABB-free@home HTTPS connection to SysAP without SSL verification, "
+                "This connection may not be secure. Consider providing an SSL certificate path and enabling SSL verification"
             )
         else:
             _LOGGER.info("HTTPS connection with SSL certificate verification enabled")

--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -181,6 +181,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Register SysAP as a Device
     _configuration_url = entry.data[CONF_HOST]
     parsed_url = urlparse(_configuration_url)
+
+    # The web interface doesn't seem to be accessible via https, sends the browser into a looping pattern.
+    # Because of this, register the SysAP with http config url instead of https
     if parsed_url.scheme == "https":
         _configuration_url = urlunparse(
             (

--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -121,8 +121,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if _host.startswith("https://"):
         if not _ssl_cert_path:
             _LOGGER.warning(
-                "HTTPS connection without SSL certificate path - SSL verification will be disabled. "
-                "This connection may not be secure. Consider providing an SSL certificate path for verification."
+                "ABB-free@home HTTPS connection to SysAP without SSL certificate path - SSL verification will be disabled, "
+                "This connection may not be secure. Consider providing an SSL certificate path for verification"
             )
         else:
             _LOGGER.info("HTTPS connection with SSL certificate verification enabled")

--- a/custom_components/abbfreeathome_ci/__init__.py
+++ b/custom_components/abbfreeathome_ci/__init__.py
@@ -79,6 +79,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_INCLUDE_VIRTUAL_DEVICES, default=False): cv.boolean,
                 vol.Optional(CONF_CREATE_SUBDEVICES, default=False): cv.boolean,
                 vol.Optional(CONF_SSL_CERT_PATH): cv.string,
+                vol.Optional(CONF_VERIFY_SSL): cv.boolean,
             }
         )
     },

--- a/custom_components/abbfreeathome_ci/config_flow.py
+++ b/custom_components/abbfreeathome_ci/config_flow.py
@@ -88,22 +88,22 @@ def _schema_ssl_config() -> vol.Schema:
 async def validate_settings(
     host: str,
     client_session: ClientSession,
-    ssl_cert_path: str | None = None,
+    ssl_cert_file_path: str | None = None,
     verify_ssl: bool = True,
 ) -> tuple[FreeAtHomeSettings, dict[str, Any]]:
     """Validate the settings endpoint."""
     errors: dict[str, str] = {}
 
     # Validate SSL configuration
-    if verify_ssl and not ssl_cert_path:
-        errors["ssl_cert_path"] = "ssl_cert_required_when_verify_enabled"
+    if verify_ssl and not ssl_cert_file_path:
+        errors["ssl_cert_file_path"] = "ssl_cert_required_when_verify_enabled"
         return None, errors
 
     settings: FreeAtHomeSettings = FreeAtHomeSettings(
         host=host,
         client_session=client_session,
         verify_ssl=verify_ssl,
-        ssl_cert_ca_file=ssl_cert_path,
+        ssl_cert_ca_file=ssl_cert_file_path,
     )
 
     try:
@@ -117,8 +117,8 @@ async def validate_settings(
         errors["base"] = "cannot_connect"
         _LOGGER.exception("Client Connection Error")
     except FileNotFoundError:
-        errors["ssl_cert_path"] = "ssl_invalid_cert_path"
-        _LOGGER.exception("%s - Invalid path for certificate", ssl_cert_path)
+        errors["ssl_cert_file_path"] = "ssl_invalid_cert_path"
+        _LOGGER.exception("%s - Invalid path for certificate", ssl_cert_file_path)
 
     return settings, errors
 
@@ -128,15 +128,15 @@ async def validate_api(
     username: str,
     password: str,
     client_session: ClientSession,
-    ssl_cert_path: str | None = None,
+    ssl_cert_file_path: str | None = None,
     verify_ssl: bool = True,
 ) -> dict[str, Any]:
     """Validate the user input allows us to connect."""
     errors: dict[str, str] = {}
 
     # Validate SSL configuration
-    if verify_ssl and not ssl_cert_path:
-        errors["ssl_cert_path"] = "ssl_cert_required_when_verify_enabled"
+    if verify_ssl and not ssl_cert_file_path:
+        errors["ssl_cert_file_path"] = "ssl_cert_required_when_verify_enabled"
         return errors
 
     api = FreeAtHomeApi(
@@ -145,7 +145,7 @@ async def validate_api(
         password=password,
         client_session=client_session,
         verify_ssl=verify_ssl,
-        ssl_cert_ca_file=ssl_cert_path,
+        ssl_cert_ca_file=ssl_cert_file_path,
     )
 
     try:
@@ -160,8 +160,8 @@ async def validate_api(
         errors["base"] = "cannot_connect"
         _LOGGER.exception("Client Connection Error")
     except FileNotFoundError:
-        errors["ssl_cert_path"] = "ssl_invalid_cert_path"
-        _LOGGER.exception("%s - Invalid path for certificate", ssl_cert_path)
+        errors["ssl_cert_file_path"] = "ssl_invalid_cert_path"
+        _LOGGER.exception("%s - Invalid path for certificate", ssl_cert_file_path)
     except Exception:
         _LOGGER.exception("Unexpected exception")
         errors["base"] = "unknown"
@@ -198,7 +198,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         # Check/Get Settings
         settings, settings_errors = await validate_settings(
             host=import_data.get(CONF_HOST),
-            ssl_cert_path=import_data.get(CONF_SSL_CERT_PATH),
+            ssl_cert_file_path=import_data.get(CONF_SSL_CERT_PATH),
             verify_ssl=import_data.get(CONF_VERIFY_SSL, _default_verify_ssl),
             client_session=async_get_clientsession(self.hass),
         )
@@ -215,7 +215,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
             host=import_data.get(CONF_HOST),
             username=import_data.get(CONF_USERNAME),
             password=import_data.get(CONF_PASSWORD),
-            ssl_cert_path=import_data.get(CONF_SSL_CERT_PATH),
+            ssl_cert_file_path=import_data.get(CONF_SSL_CERT_PATH),
             verify_ssl=import_data.get(CONF_VERIFY_SSL, _default_verify_ssl),
             client_session=async_get_clientsession(self.hass),
         )
@@ -324,7 +324,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         # Now validate with SSL settings
         settings, settings_errors = await validate_settings(
             host=self._host,
-            ssl_cert_path=self._ssl_cert_path,
+            ssl_cert_file_path=self._ssl_cert_path,
             verify_ssl=self._verify_ssl,
             client_session=async_get_clientsession(self.hass),
         )
@@ -338,7 +338,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
             host=self._host,
             username=self._username,
             password=self._password,
-            ssl_cert_path=self._ssl_cert_path,
+            ssl_cert_file_path=self._ssl_cert_path,
             verify_ssl=self._verify_ssl,
             client_session=async_get_clientsession(self.hass),
         )
@@ -473,7 +473,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         # Check/Get Settings with new host
         settings, settings_errors = await validate_settings(
             host=user_input[CONF_HOST],
-            ssl_cert_path=user_input.get(CONF_SSL_CERT_PATH),
+            ssl_cert_file_path=user_input.get(CONF_SSL_CERT_PATH),
             verify_ssl=user_input.get(CONF_VERIFY_SSL),
             client_session=async_get_clientsession(self.hass),
         )
@@ -488,7 +488,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
             host=user_input[CONF_HOST],
             username=user_input[CONF_USERNAME],
             password=user_input[CONF_PASSWORD],
-            ssl_cert_path=user_input.get(CONF_SSL_CERT_PATH),
+            ssl_cert_file_path=user_input.get(CONF_SSL_CERT_PATH),
             verify_ssl=user_input.get(CONF_VERIFY_SSL),
             client_session=async_get_clientsession(self.hass),
         )

--- a/custom_components/abbfreeathome_ci/config_flow.py
+++ b/custom_components/abbfreeathome_ci/config_flow.py
@@ -116,6 +116,9 @@ async def validate_settings(
     except ClientConnectionError:
         errors["base"] = "cannot_connect"
         _LOGGER.exception("Client Connection Error")
+    except FileNotFoundError:
+        errors["ssl_cert_path"] = "ssl_invalid_cert_path"
+        _LOGGER.exception("%s - Invalid path for certificate", ssl_cert_path)
 
     return settings, errors
 
@@ -156,6 +159,9 @@ async def validate_api(
     except ClientConnectionError:
         errors["base"] = "cannot_connect"
         _LOGGER.exception("Client Connection Error")
+    except FileNotFoundError:
+        errors["ssl_cert_path"] = "ssl_invalid_cert_path"
+        _LOGGER.exception("%s - Invalid path for certificate", ssl_cert_path)
     except Exception:
         _LOGGER.exception("Unexpected exception")
         errors["base"] = "unknown"

--- a/custom_components/abbfreeathome_ci/config_flow.py
+++ b/custom_components/abbfreeathome_ci/config_flow.py
@@ -33,7 +33,7 @@ from .const import (
     CONF_INCLUDE_ORPHAN_CHANNELS,
     CONF_INCLUDE_VIRTUAL_DEVICES,
     CONF_SERIAL,
-    CONF_SSL_CERT_PATH,
+    CONF_SSL_CERT_FILE_PATH,
     CONF_VERIFY_SSL,
     DOMAIN,
     SYSAP_VERSION,
@@ -46,7 +46,7 @@ def _schema_ssl_cert_fields() -> dict:
     """Get SSL configuration fields schema."""
     return {
         vol.Optional(CONF_VERIFY_SSL, description={"suggested_value": True}): bool,
-        vol.Optional(CONF_SSL_CERT_PATH): str,
+        vol.Optional(CONF_SSL_CERT_FILE_PATH): str,
     }
 
 
@@ -198,7 +198,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         # Check/Get Settings
         settings, settings_errors = await validate_settings(
             host=import_data.get(CONF_HOST),
-            ssl_cert_file_path=import_data.get(CONF_SSL_CERT_PATH),
+            ssl_cert_file_path=import_data.get(CONF_SSL_CERT_FILE_PATH),
             verify_ssl=import_data.get(CONF_VERIFY_SSL, _default_verify_ssl),
             client_session=async_get_clientsession(self.hass),
         )
@@ -215,7 +215,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
             host=import_data.get(CONF_HOST),
             username=import_data.get(CONF_USERNAME),
             password=import_data.get(CONF_PASSWORD),
-            ssl_cert_file_path=import_data.get(CONF_SSL_CERT_PATH),
+            ssl_cert_file_path=import_data.get(CONF_SSL_CERT_FILE_PATH),
             verify_ssl=import_data.get(CONF_VERIFY_SSL, _default_verify_ssl),
             client_session=async_get_clientsession(self.hass),
         )
@@ -237,7 +237,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._include_orphan_channels = import_data.get(CONF_INCLUDE_ORPHAN_CHANNELS)
         self._include_virtual_devices = import_data.get(CONF_INCLUDE_VIRTUAL_DEVICES)
         self._create_subdevices = import_data.get(CONF_CREATE_SUBDEVICES)
-        self._ssl_cert_path = import_data.get(CONF_SSL_CERT_PATH)
+        self._ssl_cert_path = import_data.get(CONF_SSL_CERT_FILE_PATH)
         self._verify_ssl = import_data.get(CONF_VERIFY_SSL, _default_verify_ssl)
 
         # If SysAP already exists, update configuration and abort.
@@ -250,7 +250,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_INCLUDE_ORPHAN_CHANNELS: self._include_orphan_channels,
                 CONF_INCLUDE_VIRTUAL_DEVICES: self._include_virtual_devices,
                 CONF_CREATE_SUBDEVICES: self._create_subdevices,
-                CONF_SSL_CERT_PATH: self._ssl_cert_path,
+                CONF_SSL_CERT_FILE_PATH: self._ssl_cert_path,
                 CONF_VERIFY_SSL: self._verify_ssl,
             }
         )
@@ -318,7 +318,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
             return self._async_show_setup_form(step_id="ssl_config")
 
         # Store SSL configuration
-        self._ssl_cert_path = user_input.get(CONF_SSL_CERT_PATH)
+        self._ssl_cert_path = user_input.get(CONF_SSL_CERT_FILE_PATH)
         self._verify_ssl = user_input.get(CONF_VERIFY_SSL)
 
         # Now validate with SSL settings
@@ -473,7 +473,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         # Check/Get Settings with new host
         settings, settings_errors = await validate_settings(
             host=user_input[CONF_HOST],
-            ssl_cert_file_path=user_input.get(CONF_SSL_CERT_PATH),
+            ssl_cert_file_path=user_input.get(CONF_SSL_CERT_FILE_PATH),
             verify_ssl=user_input.get(CONF_VERIFY_SSL),
             client_session=async_get_clientsession(self.hass),
         )
@@ -488,7 +488,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
             host=user_input[CONF_HOST],
             username=user_input[CONF_USERNAME],
             password=user_input[CONF_PASSWORD],
-            ssl_cert_file_path=user_input.get(CONF_SSL_CERT_PATH),
+            ssl_cert_file_path=user_input.get(CONF_SSL_CERT_FILE_PATH),
             verify_ssl=user_input.get(CONF_VERIFY_SSL),
             client_session=async_get_clientsession(self.hass),
         )
@@ -506,7 +506,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._include_orphan_channels = user_input[CONF_INCLUDE_ORPHAN_CHANNELS]
         self._include_virtual_devices = user_input[CONF_INCLUDE_VIRTUAL_DEVICES]
         self._create_subdevices = user_input[CONF_CREATE_SUBDEVICES]
-        self._ssl_cert_path = user_input.get(CONF_SSL_CERT_PATH)
+        self._ssl_cert_path = user_input.get(CONF_SSL_CERT_FILE_PATH)
         self._verify_ssl = user_input.get(CONF_VERIFY_SSL)
 
         return self._async_update_reload_and_abort()
@@ -524,7 +524,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_INCLUDE_ORPHAN_CHANNELS: self._include_orphan_channels,
                 CONF_INCLUDE_VIRTUAL_DEVICES: self._include_virtual_devices,
                 CONF_CREATE_SUBDEVICES: self._create_subdevices,
-                CONF_SSL_CERT_PATH: self._ssl_cert_path,
+                CONF_SSL_CERT_FILE_PATH: self._ssl_cert_path,
                 CONF_VERIFY_SSL: self._verify_ssl,
             },
         )
@@ -575,7 +575,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_INCLUDE_ORPHAN_CHANNELS: self._include_orphan_channels,
                 CONF_INCLUDE_VIRTUAL_DEVICES: self._include_virtual_devices,
                 CONF_CREATE_SUBDEVICES: self._create_subdevices,
-                CONF_SSL_CERT_PATH: self._ssl_cert_path,
+                CONF_SSL_CERT_FILE_PATH: self._ssl_cert_path,
                 CONF_VERIFY_SSL: self._verify_ssl,
             },
         )

--- a/custom_components/abbfreeathome_ci/config_flow.py
+++ b/custom_components/abbfreeathome_ci/config_flow.py
@@ -66,7 +66,10 @@ def _schema_with_defaults(
                 CONF_INCLUDE_VIRTUAL_DEVICES, default=include_virtual_devices
             ): bool,
             vol.Optional(CONF_CREATE_SUBDEVICES, default=create_subdevices): bool,
-            vol.Optional(CONF_SSL_CERT_PATH, default=ssl_cert_path): str,
+            vol.Optional(
+                CONF_SSL_CERT_PATH,
+                **({} if ssl_cert_path is None else {"default": ssl_cert_path}),
+            ): str,
         }
     )
 

--- a/custom_components/abbfreeathome_ci/config_flow.py
+++ b/custom_components/abbfreeathome_ci/config_flow.py
@@ -188,7 +188,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._include_orphan_channels: bool = False
         self._include_virtual_devices: bool = False
         self._create_subdevices: bool = False
-        self._ssl_cert_path: str | None = None
+        self._ssl_cert_file_path: str | None = None
         self._verify_ssl: bool = True
 
     async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
@@ -237,7 +237,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._include_orphan_channels = import_data.get(CONF_INCLUDE_ORPHAN_CHANNELS)
         self._include_virtual_devices = import_data.get(CONF_INCLUDE_VIRTUAL_DEVICES)
         self._create_subdevices = import_data.get(CONF_CREATE_SUBDEVICES)
-        self._ssl_cert_path = import_data.get(CONF_SSL_CERT_FILE_PATH)
+        self._ssl_cert_file_path = import_data.get(CONF_SSL_CERT_FILE_PATH)
         self._verify_ssl = import_data.get(CONF_VERIFY_SSL, _default_verify_ssl)
 
         # If SysAP already exists, update configuration and abort.
@@ -250,7 +250,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_INCLUDE_ORPHAN_CHANNELS: self._include_orphan_channels,
                 CONF_INCLUDE_VIRTUAL_DEVICES: self._include_virtual_devices,
                 CONF_CREATE_SUBDEVICES: self._create_subdevices,
-                CONF_SSL_CERT_FILE_PATH: self._ssl_cert_path,
+                CONF_SSL_CERT_FILE_PATH: self._ssl_cert_file_path,
                 CONF_VERIFY_SSL: self._verify_ssl,
             }
         )
@@ -318,13 +318,13 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
             return self._async_show_setup_form(step_id="ssl_config")
 
         # Store SSL configuration
-        self._ssl_cert_path = user_input.get(CONF_SSL_CERT_FILE_PATH)
+        self._ssl_cert_file_path = user_input.get(CONF_SSL_CERT_FILE_PATH)
         self._verify_ssl = user_input.get(CONF_VERIFY_SSL)
 
         # Now validate with SSL settings
         settings, settings_errors = await validate_settings(
             host=self._host,
-            ssl_cert_file_path=self._ssl_cert_path,
+            ssl_cert_file_path=self._ssl_cert_file_path,
             verify_ssl=self._verify_ssl,
             client_session=async_get_clientsession(self.hass),
         )
@@ -338,7 +338,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
             host=self._host,
             username=self._username,
             password=self._password,
-            ssl_cert_file_path=self._ssl_cert_path,
+            ssl_cert_file_path=self._ssl_cert_file_path,
             verify_ssl=self._verify_ssl,
             client_session=async_get_clientsession(self.hass),
         )
@@ -506,7 +506,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._include_orphan_channels = user_input[CONF_INCLUDE_ORPHAN_CHANNELS]
         self._include_virtual_devices = user_input[CONF_INCLUDE_VIRTUAL_DEVICES]
         self._create_subdevices = user_input[CONF_CREATE_SUBDEVICES]
-        self._ssl_cert_path = user_input.get(CONF_SSL_CERT_FILE_PATH)
+        self._ssl_cert_file_path = user_input.get(CONF_SSL_CERT_FILE_PATH)
         self._verify_ssl = user_input.get(CONF_VERIFY_SSL)
 
         return self._async_update_reload_and_abort()
@@ -524,7 +524,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_INCLUDE_ORPHAN_CHANNELS: self._include_orphan_channels,
                 CONF_INCLUDE_VIRTUAL_DEVICES: self._include_virtual_devices,
                 CONF_CREATE_SUBDEVICES: self._create_subdevices,
-                CONF_SSL_CERT_FILE_PATH: self._ssl_cert_path,
+                CONF_SSL_CERT_FILE_PATH: self._ssl_cert_file_path,
                 CONF_VERIFY_SSL: self._verify_ssl,
             },
         )
@@ -575,7 +575,7 @@ class FreeAtHomeConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_INCLUDE_ORPHAN_CHANNELS: self._include_orphan_channels,
                 CONF_INCLUDE_VIRTUAL_DEVICES: self._include_virtual_devices,
                 CONF_CREATE_SUBDEVICES: self._create_subdevices,
-                CONF_SSL_CERT_FILE_PATH: self._ssl_cert_path,
+                CONF_SSL_CERT_FILE_PATH: self._ssl_cert_file_path,
                 CONF_VERIFY_SSL: self._verify_ssl,
             },
         )

--- a/custom_components/abbfreeathome_ci/const.py
+++ b/custom_components/abbfreeathome_ci/const.py
@@ -9,6 +9,7 @@ CONF_INCLUDE_ORPHAN_CHANNELS = "include_orphan_channels"
 CONF_INCLUDE_VIRTUAL_DEVICES = "include_virtual_devices"
 CONF_CREATE_SUBDEVICES = "create_subdevices"
 CONF_SSL_CERT_PATH = "ssl_cert_path"
+CONF_VERIFY_SSL = "verify_ssl"
 
 # SysAP Settings
 SYSAP_VERSION = "sysap_version"

--- a/custom_components/abbfreeathome_ci/const.py
+++ b/custom_components/abbfreeathome_ci/const.py
@@ -8,6 +8,7 @@ CONF_SERIAL = "serial"
 CONF_INCLUDE_ORPHAN_CHANNELS = "include_orphan_channels"
 CONF_INCLUDE_VIRTUAL_DEVICES = "include_virtual_devices"
 CONF_CREATE_SUBDEVICES = "create_subdevices"
+CONF_SSL_CERT_PATH = "ssl_cert_path"
 
 # SysAP Settings
 SYSAP_VERSION = "sysap_version"

--- a/custom_components/abbfreeathome_ci/const.py
+++ b/custom_components/abbfreeathome_ci/const.py
@@ -8,7 +8,7 @@ CONF_SERIAL = "serial"
 CONF_INCLUDE_ORPHAN_CHANNELS = "include_orphan_channels"
 CONF_INCLUDE_VIRTUAL_DEVICES = "include_virtual_devices"
 CONF_CREATE_SUBDEVICES = "create_subdevices"
-CONF_SSL_CERT_PATH = "ssl_cert_file_path"
+CONF_SSL_CERT_FILE_PATH = "ssl_cert_file_path"
 CONF_VERIFY_SSL = "verify_ssl"
 
 # SysAP Settings

--- a/custom_components/abbfreeathome_ci/const.py
+++ b/custom_components/abbfreeathome_ci/const.py
@@ -8,7 +8,7 @@ CONF_SERIAL = "serial"
 CONF_INCLUDE_ORPHAN_CHANNELS = "include_orphan_channels"
 CONF_INCLUDE_VIRTUAL_DEVICES = "include_virtual_devices"
 CONF_CREATE_SUBDEVICES = "create_subdevices"
-CONF_SSL_CERT_PATH = "ssl_cert_path"
+CONF_SSL_CERT_PATH = "ssl_cert_file_path"
 CONF_VERIFY_SSL = "verify_ssl"
 
 # SysAP Settings

--- a/custom_components/abbfreeathome_ci/manifest.json
+++ b/custom_components/abbfreeathome_ci/manifest.json
@@ -8,9 +8,9 @@
   "homekit": {},
   "iot_class": "local_push",
   "loggers": ["abbfreeathome"],
-  "requirements": ["local-abbfreeathome==3.1.1"],
+  "requirements": ["local-abbfreeathome==3.1.2"],
   "ssdp": [],
-  "version": "1.8.0",
+  "version": "1.9.0b1",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -10,7 +10,11 @@
           "password": "[%key:common::config_flow::data::password%]",
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
           "include_virtual_devices": "Include virtual devices?",
-          "create_subdevices": "Create Sub-Devices for each independent channel?"
+          "create_subdevices": "Create Sub-Devices for each independent channel?",
+          "ssl_cert_path": "SSL Certificate File Path (optional)"
+        },
+        "data_description": {
+          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
         }
       },
       "zeroconf_confirm": {
@@ -22,7 +26,11 @@
           "password": "[%key:common::config_flow::data::password%]",
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
           "include_virtual_devices": "Include virtual devices?",
-          "create_subdevices": "Create Sub-Devices for each independent channel?"
+          "create_subdevices": "Create Sub-Devices for each independent channel?",
+          "ssl_cert_path": "SSL Certificate File Path (optional)"
+        },
+        "data_description": {
+          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
         }
       },
       "reconfigure": {
@@ -33,7 +41,11 @@
           "password": "[%key:common::config_flow::data::password%]",
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
           "include_virtual_devices": "Include virtual devices?",
-          "create_subdevices": "Create Sub-Devices for each independent channel?"
+          "create_subdevices": "Create Sub-Devices for each independent channel?",
+          "ssl_cert_path": "SSL Certificate File Path (optional)"
+        },
+        "data_description": {
+          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
         }
       }
     },

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -1,6 +1,16 @@
 {
   "config": {
     "step": {
+      "ssl_config": {
+        "title": "ABB-free@home - SSL Configuration",
+        "description": "Configure SSL settings for HTTPS connection to {host}",
+        "data": {
+          "ssl_cert_path": "SSL Certificate File Path (optional)"
+        },
+        "data_description": {
+          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
+        }
+      },
       "user": {
         "title": "ABB-free@home - Configure",
         "description": "Enter the hostname/ip address (with schema, e.g. http://), username, and password of your ABB-free@home SysAP to integrate with Home Assistant.",
@@ -10,11 +20,7 @@
           "password": "[%key:common::config_flow::data::password%]",
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
           "include_virtual_devices": "Include virtual devices?",
-          "create_subdevices": "Create Sub-Devices for each independent channel?",
-          "ssl_cert_path": "SSL Certificate File Path (optional)"
-        },
-        "data_description": {
-          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
+          "create_subdevices": "Create Sub-Devices for each independent channel?"
         }
       },
       "zeroconf_confirm": {

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -5,7 +5,7 @@
         "title": "ABB-free@home - SSL Configuration",
         "description": "Configure SSL settings for HTTPS connection to {host}",
         "data": {
-          "ssl_cert_path": "SSL Certificate File Path (optional)"
+          "ssl_cert_path": "SSL Certificate File Path"
         },
         "data_description": {
           "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
@@ -33,7 +33,7 @@
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
           "include_virtual_devices": "Include virtual devices?",
           "create_subdevices": "Create Sub-Devices for each independent channel?",
-          "ssl_cert_path": "SSL Certificate File Path (optional)"
+          "ssl_cert_path": "SSL Certificate File Path"
         },
         "data_description": {
           "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
@@ -48,7 +48,7 @@
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
           "include_virtual_devices": "Include virtual devices?",
           "create_subdevices": "Create Sub-Devices for each independent channel?",
-          "ssl_cert_path": "SSL Certificate File Path (optional)"
+          "ssl_cert_path": "SSL Certificate File Path"
         },
         "data_description": {
           "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -10,7 +10,7 @@
         },
         "data_description": {
           "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. Required when SSL verification is enabled.",
-          "verify_ssl": "Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate (not recommended for production)."
+          "verify_ssl": "Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate."
         }
       },
       "user": {
@@ -34,11 +34,7 @@
           "password": "[%key:common::config_flow::data::password%]",
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
           "include_virtual_devices": "Include virtual devices?",
-          "create_subdevices": "Create Sub-Devices for each independent channel?",
-          "ssl_cert_path": "SSL Certificate File Path"
-        },
-        "data_description": {
-          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
+          "create_subdevices": "Create Sub-Devices for each independent channel?"
         }
       },
       "reconfigure": {
@@ -50,10 +46,12 @@
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
           "include_virtual_devices": "Include virtual devices?",
           "create_subdevices": "Create Sub-Devices for each independent channel?",
-          "ssl_cert_path": "SSL Certificate File Path"
+          "ssl_cert_path": "SSL Certificate File Path",
+          "verify_ssl": "Verify SSL Certificate"
         },
         "data_description": {
-          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
+          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled.",
+          "verify_ssl": "Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate."
         }
       }
     },

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -59,6 +59,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "ssl_cert_required_when_verify_enabled": "SSL certificate path is required when SSL verification is enabled",
+      "ssl_invalid_cert_path": "Could not find SSL certificate",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "unsupported_sysap_version": "The current version {sysap_version} of the SysAP is not supported. Only version 2.6.0 or newer is supported."
     },

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -5,10 +5,12 @@
         "title": "ABB-free@home - SSL Configuration",
         "description": "Configure SSL settings for HTTPS connection to {host}",
         "data": {
-          "ssl_cert_path": "SSL Certificate File Path"
+          "ssl_cert_path": "SSL Certificate File Path",
+          "verify_ssl": "Verify SSL Certificate"
         },
         "data_description": {
-          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
+          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. Required when SSL verification is enabled.",
+          "verify_ssl": "Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate (not recommended for production)."
         }
       },
       "user": {
@@ -58,6 +60,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "ssl_cert_required_when_verify_enabled": "SSL certificate path is required when SSL verification is enabled",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "unsupported_sysap_version": "The current version {sysap_version} of the SysAP is not supported. Only version 2.6.0 or newer is supported."
     },

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -5,11 +5,11 @@
         "title": "ABB-free@home - SSL Configuration",
         "description": "Configure SSL settings for HTTPS connection to {host}",
         "data": {
-          "ssl_cert_path": "SSL Certificate File Path",
+          "ssl_cert_file_path": "SSL Certificate File Path",
           "verify_ssl": "Verify SSL Certificate"
         },
         "data_description": {
-          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. Required when SSL verification is enabled.",
+          "ssl_cert_file_path": "Path to SSL certificate file for HTTPS connections. Required when SSL verification is enabled.",
           "verify_ssl": "Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate."
         }
       },
@@ -46,11 +46,11 @@
           "include_orphan_channels": "Include channels NOT on the ABB-free@home floorplan?",
           "include_virtual_devices": "Include virtual devices?",
           "create_subdevices": "Create Sub-Devices for each independent channel?",
-          "ssl_cert_path": "SSL Certificate File Path",
+          "ssl_cert_file_path": "SSL Certificate File Path",
           "verify_ssl": "Verify SSL Certificate"
         },
         "data_description": {
-          "ssl_cert_path": "Path to SSL certificate file to verify HTTPS/SSL connections.",
+          "ssl_cert_file_path": "Path to SSL certificate file to verify HTTPS/SSL connections.",
           "verify_ssl": "Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate."
         }
       }

--- a/custom_components/abbfreeathome_ci/strings.json
+++ b/custom_components/abbfreeathome_ci/strings.json
@@ -50,7 +50,7 @@
           "verify_ssl": "Verify SSL Certificate"
         },
         "data_description": {
-          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled.",
+          "ssl_cert_path": "Path to SSL certificate file to verify HTTPS/SSL connections.",
           "verify_ssl": "Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate."
         }
       }

--- a/custom_components/abbfreeathome_ci/translations/de.json
+++ b/custom_components/abbfreeathome_ci/translations/de.json
@@ -10,7 +10,11 @@
           "password": "Passwort",
           "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
           "include_virtual_devices": "Virtuelle Geräte einschließen?",
-          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?"
+          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?",
+          "ssl_cert_path": "SSL-Zertifikatsdateipfad (optional)"
+        },
+        "data_description": {
+          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Bei Verwendung von HTTPS ohne Zertifikat wird die SSL-Überprüfung deaktiviert (nicht für Produktionssysteme empfohlen)."
         }
       },
       "zeroconf_confirm": {
@@ -22,7 +26,11 @@
           "password": "Passwort",
           "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
           "include_virtual_devices": "Virtuelle Geräte einschließen?",
-          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?"
+          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?",
+          "ssl_cert_path": "SSL-Zertifikatsdateipfad (optional)"
+        },
+        "data_description": {
+          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Bei Verwendung von HTTPS ohne Zertifikat wird die SSL-Überprüfung deaktiviert (nicht für Produktionssysteme empfohlen)."
         }
       },
       "reconfigure": {
@@ -33,7 +41,11 @@
           "password": "Passwort",
           "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
           "include_virtual_devices": "Virtuelle Geräte einschließen?",
-          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?"
+          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?",
+          "ssl_cert_path": "SSL-Zertifikatsdateipfad (optional)"
+        },
+        "data_description": {
+          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Bei Verwendung von HTTPS ohne Zertifikat wird die SSL-Überprüfung deaktiviert (nicht für Produktionssysteme empfohlen)."
         }
       }
     },

--- a/custom_components/abbfreeathome_ci/translations/de.json
+++ b/custom_components/abbfreeathome_ci/translations/de.json
@@ -1,6 +1,16 @@
 {
   "config": {
     "step": {
+      "ssl_config": {
+        "title": "ABB-free@home - SSL-Konfiguration",
+        "description": "SSL-Einstellungen für HTTPS-Verbindung zu {host} konfigurieren",
+        "data": {
+          "ssl_cert_path": "SSL-Zertifikatsdateipfad (optional)"
+        },
+        "data_description": {
+          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Bei Verwendung von HTTPS ohne Zertifikat wird die SSL-Überprüfung deaktiviert (nicht für Produktionssysteme empfohlen)."
+        }
+      },
       "user": {
         "title": "ABB-free@home - Konfiguration",
         "description": "Trage den Hostnamen/IP-Adresse (mit Schema, z.B. http://), Benutzername und Passwort von Deinem ABB-free@home SysAP ein, den Du in Home Assistant integrieren möchtest.",
@@ -10,11 +20,7 @@
           "password": "Passwort",
           "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
           "include_virtual_devices": "Virtuelle Geräte einschließen?",
-          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?",
-          "ssl_cert_path": "SSL-Zertifikatsdateipfad (optional)"
-        },
-        "data_description": {
-          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Bei Verwendung von HTTPS ohne Zertifikat wird die SSL-Überprüfung deaktiviert (nicht für Produktionssysteme empfohlen)."
+          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?"
         }
       },
       "zeroconf_confirm": {

--- a/custom_components/abbfreeathome_ci/translations/de.json
+++ b/custom_components/abbfreeathome_ci/translations/de.json
@@ -11,6 +11,7 @@
       "cannot_connect": "Verbindung fehlgeschlagen",
       "invalid_auth": "Ungültige Authentifizierung",
       "ssl_cert_required_when_verify_enabled": "SSL-Zertifikatspfad ist erforderlich, wenn SSL-Überprüfung aktiviert ist",
+      "ssl_invalid_cert_path": "Could not find SSL certificate",
       "unknown": "Unerwarteter Fehler",
       "unsupported_sysap_version": "Die aktuelle Version {sysap_version} des SysAP wird nicht unterstützt. Nur Version 2.6.0 oder neuer wird unterstützt."
     },

--- a/custom_components/abbfreeathome_ci/translations/de.json
+++ b/custom_components/abbfreeathome_ci/translations/de.json
@@ -5,7 +5,7 @@
         "title": "ABB-free@home - SSL-Konfiguration",
         "description": "SSL-Einstellungen für HTTPS-Verbindung zu {host} konfigurieren",
         "data": {
-          "ssl_cert_path": "SSL-Zertifikatsdateipfad (optional)"
+          "ssl_cert_path": "SSL-Zertifikatsdateipfad"
         },
         "data_description": {
           "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Bei Verwendung von HTTPS ohne Zertifikat wird die SSL-Überprüfung deaktiviert (nicht für Produktionssysteme empfohlen)."
@@ -33,7 +33,7 @@
           "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
           "include_virtual_devices": "Virtuelle Geräte einschließen?",
           "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?",
-          "ssl_cert_path": "SSL-Zertifikatsdateipfad (optional)"
+          "ssl_cert_path": "SSL-Zertifikatsdateipfad"
         },
         "data_description": {
           "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Bei Verwendung von HTTPS ohne Zertifikat wird die SSL-Überprüfung deaktiviert (nicht für Produktionssysteme empfohlen)."
@@ -48,7 +48,7 @@
           "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
           "include_virtual_devices": "Virtuelle Geräte einschließen?",
           "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?",
-          "ssl_cert_path": "SSL-Zertifikatsdateipfad (optional)"
+          "ssl_cert_path": "SSL-Zertifikatsdateipfad"
         },
         "data_description": {
           "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Bei Verwendung von HTTPS ohne Zertifikat wird die SSL-Überprüfung deaktiviert (nicht für Produktionssysteme empfohlen)."

--- a/custom_components/abbfreeathome_ci/translations/de.json
+++ b/custom_components/abbfreeathome_ci/translations/de.json
@@ -1,61 +1,11 @@
 {
   "config": {
-    "step": {
-      "ssl_config": {
-        "title": "ABB-free@home - SSL-Konfiguration",
-        "description": "SSL-Einstellungen für HTTPS-Verbindung zu {host} konfigurieren",
-        "data": {
-          "ssl_cert_path": "SSL-Zertifikatsdateipfad",
-          "verify_ssl": "SSL-Zertifikat überprüfen"
-        },
-        "data_description": {
-          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Erforderlich, wenn SSL-Überprüfung aktiviert ist.",
-          "verify_ssl": "SSL-Zertifikatsüberprüfung aktivieren. Wenn deaktiviert, werden HTTPS-Verbindungen das Serverzertifikat nicht überprüfen (nicht für Produktionssysteme empfohlen)."
-        }
-      },
-      "user": {
-        "title": "ABB-free@home - Konfiguration",
-        "description": "Trage den Hostnamen/IP-Adresse (mit Schema, z.B. http://), Benutzername und Passwort von Deinem ABB-free@home SysAP ein, den Du in Home Assistant integrieren möchtest.",
-        "data": {
-          "host": "Host",
-          "username": "Benutzername",
-          "password": "Passwort",
-          "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
-          "include_virtual_devices": "Virtuelle Geräte einschließen?",
-          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?"
-        }
-      },
-      "zeroconf_confirm": {
-        "title": "ABB-free@home - Bestätigung",
-        "description": "Möchten Sie {name} ({serial}) auf {host} einrichten?",
-        "data": {
-          "host": "Host",
-          "username": "Benutzername",
-          "password": "Passwort",
-          "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
-          "include_virtual_devices": "Virtuelle Geräte einschließen?",
-          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?",
-          "ssl_cert_path": "SSL-Zertifikatsdateipfad"
-        },
-        "data_description": {
-          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Bei Verwendung von HTTPS ohne Zertifikat wird die SSL-Überprüfung deaktiviert (nicht für Produktionssysteme empfohlen)."
-        }
-      },
-      "reconfigure": {
-        "title": "ABB-free@home - Neukonfiguration",
-        "description": "Möchten Sie {name} ({serial}) auf {host} neu konfigurieren?",
-        "data": {
-          "username": "Benutzername",
-          "password": "Passwort",
-          "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
-          "include_virtual_devices": "Virtuelle Geräte einschließen?",
-          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?",
-          "ssl_cert_path": "SSL-Zertifikatsdateipfad"
-        },
-        "data_description": {
-          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Bei Verwendung von HTTPS ohne Zertifikat wird die SSL-Überprüfung deaktiviert (nicht für Produktionssysteme empfohlen)."
-        }
-      }
+    "abort": {
+      "already_configured": "Gerät ist bereits konfiguriert",
+      "already_in_progress": "Konfigurationsablauf wird bereits ausgeführt",
+      "reauth_successful": "Die erneute Authentifizierung war erfolgreich",
+      "reconfigure_not_supported": "Die Neukonfiguration für diese Integration wird nur ab Home Assistant Version 2024.11.0 unterstützt.",
+      "reconfigure_successful": "Die Neukonfiguration war erfolgreich"
     },
     "error": {
       "cannot_connect": "Verbindung fehlgeschlagen",
@@ -64,12 +14,60 @@
       "unknown": "Unerwarteter Fehler",
       "unsupported_sysap_version": "Die aktuelle Version {sysap_version} des SysAP wird nicht unterstützt. Nur Version 2.6.0 oder neuer wird unterstützt."
     },
-    "abort": {
-      "already_configured": "Gerät ist bereits konfiguriert",
-      "already_in_progress": "Konfigurationsablauf wird bereits ausgeführt",
-      "reauth_successful": "Die erneute Authentifizierung war erfolgreich",
-      "reconfigure_successful": "Die Neukonfiguration war erfolgreich",
-      "reconfigure_not_supported": "Die Neukonfiguration für diese Integration wird nur ab Home Assistant Version 2024.11.0 unterstützt."
+    "step": {
+      "reconfigure": {
+        "data": {
+          "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
+          "include_virtual_devices": "Virtuelle Geräte einschließen?",
+          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?",
+          "password": "Passwort",
+          "username": "Benutzername",
+          "ssl_cert_path": "SSL-Zertifikatsdateipfad",
+          "verify_ssl": "SSL-Zertifikat überprüfen"
+        },
+        "data_description": {
+          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Bei Verwendung von HTTPS ohne Zertifikat wird die SSL-Überprüfung deaktiviert.",
+          "verify_ssl": "SSL-Zertifikatsüberprüfung aktivieren. Wenn deaktiviert, werden HTTPS-Verbindungen das Serverzertifikat nicht überprüfen."
+        },
+        "description": "Möchten Sie {name} ({serial}) auf {host} neu konfigurieren?",
+        "title": "ABB-free@home - Neukonfiguration"
+      },
+      "ssl_config": {
+        "data": {
+          "ssl_cert_path": "SSL-Zertifikatsdateipfad",
+          "verify_ssl": "SSL-Zertifikat überprüfen"
+        },
+        "data_description": {
+          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Erforderlich, wenn SSL-Überprüfung aktiviert ist.",
+          "verify_ssl": "SSL-Zertifikatsüberprüfung aktivieren. Wenn deaktiviert, werden HTTPS-Verbindungen das Serverzertifikat nicht überprüfen."
+        },
+        "description": "SSL-Einstellungen für HTTPS-Verbindung zu {host} konfigurieren",
+        "title": "ABB-free@home - SSL-Konfiguration"
+      },
+      "user": {
+        "data": {
+          "host": "Host",
+          "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
+          "include_virtual_devices": "Virtuelle Geräte einschließen?",
+          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?",
+          "password": "Passwort",
+          "username": "Benutzername"
+        },
+        "description": "Trage den Hostnamen/IP-Adresse (mit Schema, z.B. http://), Benutzername und Passwort von Deinem ABB-free@home SysAP ein, den Du in Home Assistant integrieren möchtest.",
+        "title": "ABB-free@home - Konfiguration"
+      },
+      "zeroconf_confirm": {
+        "data": {
+          "host": "Host",
+          "include_orphan_channels": "Kanäle einschließen, die NICHT im ABB-free@home Grundriss enthalten sind?",
+          "include_virtual_devices": "Virtuelle Geräte einschließen?",
+          "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?",
+          "password": "Passwort",
+          "username": "Benutzername"
+        },
+        "description": "Möchten Sie {name} ({serial}) auf {host} einrichten?",
+        "title": "ABB-free@home - Bestätigung"
+      }
     }
   },
   "entity": {

--- a/custom_components/abbfreeathome_ci/translations/de.json
+++ b/custom_components/abbfreeathome_ci/translations/de.json
@@ -27,7 +27,7 @@
           "verify_ssl": "SSL-Zertifikat überprüfen"
         },
         "data_description": {
-          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Bei Verwendung von HTTPS ohne Zertifikat wird die SSL-Überprüfung deaktiviert.",
+          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei zur Überprüfung von HTTPS/SSL-Verbindungen.",
           "verify_ssl": "SSL-Zertifikatsüberprüfung aktivieren. Wenn deaktiviert, werden HTTPS-Verbindungen das Serverzertifikat nicht überprüfen."
         },
         "description": "Möchten Sie {name} ({serial}) auf {host} neu konfigurieren?",
@@ -39,7 +39,7 @@
           "verify_ssl": "SSL-Zertifikat überprüfen"
         },
         "data_description": {
-          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Erforderlich, wenn SSL-Überprüfung aktiviert ist.",
+          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei zur Überprüfung von HTTPS/SSL-Verbindungen.",
           "verify_ssl": "SSL-Zertifikatsüberprüfung aktivieren. Wenn deaktiviert, werden HTTPS-Verbindungen das Serverzertifikat nicht überprüfen."
         },
         "description": "SSL-Einstellungen für HTTPS-Verbindung zu {host} konfigurieren",

--- a/custom_components/abbfreeathome_ci/translations/de.json
+++ b/custom_components/abbfreeathome_ci/translations/de.json
@@ -5,10 +5,12 @@
         "title": "ABB-free@home - SSL-Konfiguration",
         "description": "SSL-Einstellungen für HTTPS-Verbindung zu {host} konfigurieren",
         "data": {
-          "ssl_cert_path": "SSL-Zertifikatsdateipfad"
+          "ssl_cert_path": "SSL-Zertifikatsdateipfad",
+          "verify_ssl": "SSL-Zertifikat überprüfen"
         },
         "data_description": {
-          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Bei Verwendung von HTTPS ohne Zertifikat wird die SSL-Überprüfung deaktiviert (nicht für Produktionssysteme empfohlen)."
+          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei für HTTPS-Verbindungen. Erforderlich, wenn SSL-Überprüfung aktiviert ist.",
+          "verify_ssl": "SSL-Zertifikatsüberprüfung aktivieren. Wenn deaktiviert, werden HTTPS-Verbindungen das Serverzertifikat nicht überprüfen (nicht für Produktionssysteme empfohlen)."
         }
       },
       "user": {
@@ -58,6 +60,7 @@
     "error": {
       "cannot_connect": "Verbindung fehlgeschlagen",
       "invalid_auth": "Ungültige Authentifizierung",
+      "ssl_cert_required_when_verify_enabled": "SSL-Zertifikatspfad ist erforderlich, wenn SSL-Überprüfung aktiviert ist",
       "unknown": "Unerwarteter Fehler",
       "unsupported_sysap_version": "Die aktuelle Version {sysap_version} des SysAP wird nicht unterstützt. Nur Version 2.6.0 oder neuer wird unterstützt."
     },

--- a/custom_components/abbfreeathome_ci/translations/de.json
+++ b/custom_components/abbfreeathome_ci/translations/de.json
@@ -11,7 +11,7 @@
       "cannot_connect": "Verbindung fehlgeschlagen",
       "invalid_auth": "Ungültige Authentifizierung",
       "ssl_cert_required_when_verify_enabled": "SSL-Zertifikatspfad ist erforderlich, wenn SSL-Überprüfung aktiviert ist",
-      "ssl_invalid_cert_path": "Could not find SSL certificate",
+      "ssl_invalid_cert_path": "SSL-Zertifikat konnte nicht gefunden werden",
       "unknown": "Unerwarteter Fehler",
       "unsupported_sysap_version": "Die aktuelle Version {sysap_version} des SysAP wird nicht unterstützt. Nur Version 2.6.0 oder neuer wird unterstützt."
     },

--- a/custom_components/abbfreeathome_ci/translations/de.json
+++ b/custom_components/abbfreeathome_ci/translations/de.json
@@ -23,11 +23,11 @@
           "create_subdevices": "Extra Geräte für jeden unabhängigen Kanal erzeugen?",
           "password": "Passwort",
           "username": "Benutzername",
-          "ssl_cert_path": "SSL-Zertifikatsdateipfad",
+          "ssl_cert_file_path": "SSL-Zertifikatsdateipfad",
           "verify_ssl": "SSL-Zertifikat überprüfen"
         },
         "data_description": {
-          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei zur Überprüfung von HTTPS/SSL-Verbindungen.",
+          "ssl_cert_file_path": "Pfad zur SSL-Zertifikatsdatei zur Überprüfung von HTTPS/SSL-Verbindungen.",
           "verify_ssl": "SSL-Zertifikatsüberprüfung aktivieren. Wenn deaktiviert, werden HTTPS-Verbindungen das Serverzertifikat nicht überprüfen."
         },
         "description": "Möchten Sie {name} ({serial}) auf {host} neu konfigurieren?",
@@ -35,11 +35,11 @@
       },
       "ssl_config": {
         "data": {
-          "ssl_cert_path": "SSL-Zertifikatsdateipfad",
+          "ssl_cert_file_path": "SSL-Zertifikatsdateipfad",
           "verify_ssl": "SSL-Zertifikat überprüfen"
         },
         "data_description": {
-          "ssl_cert_path": "Pfad zur SSL-Zertifikatsdatei zur Überprüfung von HTTPS/SSL-Verbindungen.",
+          "ssl_cert_file_path": "Pfad zur SSL-Zertifikatsdatei zur Überprüfung von HTTPS/SSL-Verbindungen.",
           "verify_ssl": "SSL-Zertifikatsüberprüfung aktivieren. Wenn deaktiviert, werden HTTPS-Verbindungen das Serverzertifikat nicht überprüfen."
         },
         "description": "SSL-Einstellungen für HTTPS-Verbindung zu {host} konfigurieren",

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -21,7 +21,7 @@
           "create_subdevices": "Create Sub-Devices for each independent channel?",
           "password": "Password",
           "username": "Username",
-          "ssl_cert_path": "SSL Certificate File Path (optional)"
+          "ssl_cert_path": "SSL Certificate File Path"
         },
         "data_description": {
           "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
@@ -31,7 +31,7 @@
       },
       "ssl_config": {
         "data": {
-          "ssl_cert_path": "SSL Certificate File Path (optional)"
+          "ssl_cert_path": "SSL Certificate File Path"
         },
         "data_description": {
           "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
@@ -59,7 +59,7 @@
           "create_subdevices": "Create Sub-Devices for each independent channel?",
           "password": "Password",
           "username": "Username",
-          "ssl_cert_path": "SSL Certificate File Path (optional)"
+          "ssl_cert_path": "SSL Certificate File Path"
         },
         "data_description": {
           "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -11,6 +11,7 @@
       "cannot_connect": "Failed to connect",
       "invalid_auth": "Invalid authentication",
       "ssl_cert_required_when_verify_enabled": "SSL certificate path is required when SSL verification is enabled",
+      "ssl_invalid_cert_path": "Could not find SSL certificate",
       "unknown": "Unexpected error",
       "unsupported_sysap_version": "The current version {sysap_version} of the SysAP is not supported. Only version 2.6.0 or newer is supported."
     },

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -10,6 +10,7 @@
     "error": {
       "cannot_connect": "Failed to connect",
       "invalid_auth": "Invalid authentication",
+      "ssl_cert_required_when_verify_enabled": "SSL certificate path is required when SSL verification is enabled",
       "unknown": "Unexpected error",
       "unsupported_sysap_version": "The current version {sysap_version} of the SysAP is not supported. Only version 2.6.0 or newer is supported."
     },
@@ -31,10 +32,12 @@
       },
       "ssl_config": {
         "data": {
-          "ssl_cert_path": "SSL Certificate File Path"
+          "ssl_cert_path": "SSL Certificate File Path",
+          "verify_ssl": "Verify SSL Certificate"
         },
         "data_description": {
-          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
+          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. Required when SSL verification is enabled.",
+          "verify_ssl": "Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate (not recommended for production)."
         },
         "description": "Configure SSL settings for HTTPS connection to {host}",
         "title": "ABB-free@home - SSL Configuration"

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -23,11 +23,11 @@
           "create_subdevices": "Create Sub-Devices for each independent channel?",
           "password": "Password",
           "username": "Username",
-          "ssl_cert_path": "SSL Certificate File Path",
+          "ssl_cert_file_path": "SSL Certificate File Path",
           "verify_ssl": "Verify SSL Certificate"
         },
         "data_description": {
-          "ssl_cert_path": "Path to SSL certificate file to verify HTTPS/SSL connections.",
+          "ssl_cert_file_path": "Path to SSL certificate file to verify HTTPS/SSL connections.",
           "verify_ssl": "Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate."
         },
         "description": "Do you want reconfigure {name} ({serial}) at {host}?",
@@ -35,11 +35,11 @@
       },
       "ssl_config": {
         "data": {
-          "ssl_cert_path": "SSL Certificate File Path",
+          "ssl_cert_file_path": "SSL Certificate File Path",
           "verify_ssl": "Verify SSL Certificate"
         },
         "data_description": {
-          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. Required when SSL verification is enabled.",
+          "ssl_cert_file_path": "Path to SSL certificate file for HTTPS connections. Required when SSL verification is enabled.",
           "verify_ssl": "Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate."
         },
         "description": "Configure SSL settings for HTTPS connection to {host}",

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -29,6 +29,16 @@
         "description": "Do you want reconfigure {name} ({serial}) at {host}?",
         "title": "ABB-free@home - Reconfigure"
       },
+      "ssl_config": {
+        "data": {
+          "ssl_cert_path": "SSL Certificate File Path (optional)"
+        },
+        "data_description": {
+          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
+        },
+        "description": "Configure SSL settings for HTTPS connection to {host}",
+        "title": "ABB-free@home - SSL Configuration"
+      },
       "user": {
         "data": {
           "host": "Host",
@@ -36,11 +46,7 @@
           "include_virtual_devices": "Include virtual devices?",
           "create_subdevices": "Create Sub-Devices for each independent channel?",
           "password": "Password",
-          "username": "Username",
-          "ssl_cert_path": "SSL Certificate File Path (optional)"
-        },
-        "data_description": {
-          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
+          "username": "Username"
         },
         "description": "Enter the hostname/ip address (with schema, e.g. http://), username, and password of your ABB-free@home SysAP to integrate with Home Assistant.",
         "title": "ABB-free@home - Configure"

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -27,7 +27,7 @@
           "verify_ssl": "Verify SSL Certificate"
         },
         "data_description": {
-          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled.",
+          "ssl_cert_path": "Path to SSL certificate file to verify HTTPS/SSL connections.",
           "verify_ssl": "Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate."
         },
         "description": "Do you want reconfigure {name} ({serial}) at {host}?",

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -22,10 +22,12 @@
           "create_subdevices": "Create Sub-Devices for each independent channel?",
           "password": "Password",
           "username": "Username",
-          "ssl_cert_path": "SSL Certificate File Path"
+          "ssl_cert_path": "SSL Certificate File Path",
+          "verify_ssl": "Verify SSL Certificate"
         },
         "data_description": {
-          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
+          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled.",
+          "verify_ssl": "Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate."
         },
         "description": "Do you want reconfigure {name} ({serial}) at {host}?",
         "title": "ABB-free@home - Reconfigure"
@@ -37,7 +39,7 @@
         },
         "data_description": {
           "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. Required when SSL verification is enabled.",
-          "verify_ssl": "Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate (not recommended for production)."
+          "verify_ssl": "Enable SSL certificate verification. When disabled, HTTPS connections will not verify the server certificate."
         },
         "description": "Configure SSL settings for HTTPS connection to {host}",
         "title": "ABB-free@home - SSL Configuration"
@@ -61,11 +63,7 @@
           "include_virtual_devices": "Include virtual devices?",
           "create_subdevices": "Create Sub-Devices for each independent channel?",
           "password": "Password",
-          "username": "Username",
-          "ssl_cert_path": "SSL Certificate File Path"
-        },
-        "data_description": {
-          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
+          "username": "Username"
         },
         "description": "Do you want to set up {name} ({serial}) at {host}?",
         "title": "ABB-free@home - Confirm"

--- a/custom_components/abbfreeathome_ci/translations/en.json
+++ b/custom_components/abbfreeathome_ci/translations/en.json
@@ -20,7 +20,11 @@
           "include_virtual_devices": "Include virtual devices?",
           "create_subdevices": "Create Sub-Devices for each independent channel?",
           "password": "Password",
-          "username": "Username"
+          "username": "Username",
+          "ssl_cert_path": "SSL Certificate File Path (optional)"
+        },
+        "data_description": {
+          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
         },
         "description": "Do you want reconfigure {name} ({serial}) at {host}?",
         "title": "ABB-free@home - Reconfigure"
@@ -32,7 +36,11 @@
           "include_virtual_devices": "Include virtual devices?",
           "create_subdevices": "Create Sub-Devices for each independent channel?",
           "password": "Password",
-          "username": "Username"
+          "username": "Username",
+          "ssl_cert_path": "SSL Certificate File Path (optional)"
+        },
+        "data_description": {
+          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
         },
         "description": "Enter the hostname/ip address (with schema, e.g. http://), username, and password of your ABB-free@home SysAP to integrate with Home Assistant.",
         "title": "ABB-free@home - Configure"
@@ -44,7 +52,11 @@
           "include_virtual_devices": "Include virtual devices?",
           "create_subdevices": "Create Sub-Devices for each independent channel?",
           "password": "Password",
-          "username": "Username"
+          "username": "Username",
+          "ssl_cert_path": "SSL Certificate File Path (optional)"
+        },
+        "data_description": {
+          "ssl_cert_path": "Path to SSL certificate file for HTTPS connections. When using HTTPS without a certificate, SSL verification will be disabled (not recommended for production)."
         },
         "description": "Do you want to set up {name} ({serial}) at {host}?",
         "title": "ABB-free@home - Confirm"


### PR DESCRIPTION
This PR adds the ability to connect to the free@home SysAP via SSL for a secure connection. The SysAP provides the certificate to be used for verification.

<img width="619" height="261" alt="image" src="https://github.com/user-attachments/assets/b90657a2-64ca-43d9-891e-bb08c81e01b4" />

SSL can also be setup without verification for those who would rather not provide the SSL certificated, but this isn't recommended and will log a warning on each load.

This will add new fields in the integration configuration to setup SSL. When adding an integration for the first time you'll only be prompted for these new fields if you provide an `https` schema. This ensure's the SSL options don't clutter up the interface if `https` is not requested.

<img width="588" height="200" alt="image" src="https://github.com/user-attachments/assets/fb80d62c-c9c9-47b7-b87e-35160f917a60" />


